### PR TITLE
회원 도메인 설계

### DIFF
--- a/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
+++ b/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.gxdxx.instagram.advice;
 import com.gxdxx.instagram.dto.response.ErrorResponse;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
+import com.gxdxx.instagram.exception.UserNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -12,6 +13,11 @@ public class RestControllerExceptionAdvice {
     @ExceptionHandler(NicknameAlreadyExistsException.class)
     public ErrorResponse nicknameAlreadyExistsException(NicknameAlreadyExistsException ex) {
         return new ErrorResponse("중복된 닉네임입니다.");
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ErrorResponse userNotFoundException(UserNotFoundException ex) {
+        return new ErrorResponse("존재하지 않는 회원입니다.");
     }
 
     @ExceptionHandler(InvalidRequestException.class)

--- a/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
+++ b/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
@@ -1,0 +1,22 @@
+package com.gxdxx.instagram.advice;
+
+import com.gxdxx.instagram.dto.response.ErrorResponse;
+import com.gxdxx.instagram.exception.InvalidRequestException;
+import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestControllerExceptionAdvice {
+
+    @ExceptionHandler(NicknameAlreadyExistsException.class)
+    public ErrorResponse nicknameAlreadyExistsException(NicknameAlreadyExistsException ex) {
+        return new ErrorResponse("중복된 닉네임입니다.");
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ErrorResponse invalidRequestException(InvalidRequestException ex) {
+        return new ErrorResponse("입력값을 확인해주세요.");
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.UserLoginRequest;
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
@@ -18,7 +19,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping
+    @PostMapping("/signup")
     public UserSignUpResponse registerUser(
             @Valid UserSignUpRequest request, BindingResult bindingResult
     ) {

--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,0 +1,12 @@
+package com.gxdxx.instagram.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/users/")
+@RestController
+public class UserController {
+}

--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,12 +1,30 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.UserSignUpRequest;
+import com.gxdxx.instagram.dto.response.UserSignUpResponse;
+import com.gxdxx.instagram.exception.InvalidRequestException;
+import com.gxdxx.instagram.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/users/")
+@RequestMapping("/api/users")
 @RestController
 public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public UserSignUpResponse registerMember(
+            @Valid UserSignUpRequest request, BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+        return userService.saveUser(request);
+    }
+
 }

--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.gxdxx.instagram.controller;
 
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.service.UserService;
@@ -18,13 +19,19 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping
-    public UserSignUpResponse registerMember(
+    public UserSignUpResponse registerUser(
             @Valid UserSignUpRequest request, BindingResult bindingResult
     ) {
         if (bindingResult.hasErrors()) {
             throw new InvalidRequestException();
         }
         return userService.saveUser(request);
+    }
+
+    @DeleteMapping("/{id}")
+    public SuccessResponse deleteUser(@PathVariable("id") Long id) {
+        // TODO: JWT 토큰의 ID값으로 유저가 맞는지 확인
+        return userService.deleteUser(id);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserSignUpRequest.java
@@ -1,0 +1,7 @@
+package com.gxdxx.instagram.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
+
+public record UserSignUpRequest(@NotBlank String nickname, MultipartFile profileImage) {
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/ErrorResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/ErrorResponse.java
@@ -1,0 +1,9 @@
+package com.gxdxx.instagram.dto.response;
+
+public record ErrorResponse(String message) {
+
+    public static ErrorResponse of(String message) {
+        return new ErrorResponse(message);
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/SuccessResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/SuccessResponse.java
@@ -1,0 +1,9 @@
+package com.gxdxx.instagram.dto.response;
+
+public record SuccessResponse(String message) {
+
+    public static SuccessResponse of(String message) {
+        return new SuccessResponse(message);
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/UserSignUpResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/UserSignUpResponse.java
@@ -1,0 +1,11 @@
+package com.gxdxx.instagram.dto.response;
+
+import com.gxdxx.instagram.entity.User;
+
+public record UserSignUpResponse(Long id, String nickname, String profileImageUrl) {
+
+    public static UserSignUpResponse of(User user) {
+        return new UserSignUpResponse(user.getId(), user.getNickname(), user.getProfileImageUrl());
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/entity/User.java
+++ b/src/main/java/com/gxdxx/instagram/entity/User.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.Objects;
 
@@ -12,6 +14,8 @@ import java.util.Objects;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@SQLDelete(sql = "UPDATE user SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class User {
 
     @Id
@@ -22,6 +26,8 @@ public class User {
     private String nickname;
 
     private String profileImageUrl;
+
+    private boolean deleted = Boolean.FALSE;
 
     private User(String nickname, String profileImageUrl) {
         this.nickname = nickname;

--- a/src/main/java/com/gxdxx/instagram/entity/User.java
+++ b/src/main/java/com/gxdxx/instagram/entity/User.java
@@ -1,0 +1,47 @@
+package com.gxdxx.instagram.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.Objects;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    private String profileImageUrl;
+
+    private User(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static User of(String nickname, String profileImageUrl) {
+        return new User(nickname, profileImageUrl);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
+        return id != null && id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/exception/InvalidRequestException.java
+++ b/src/main/java/com/gxdxx/instagram/exception/InvalidRequestException.java
@@ -1,0 +1,4 @@
+package com.gxdxx.instagram.exception;
+
+public class InvalidRequestException extends RuntimeException {
+}

--- a/src/main/java/com/gxdxx/instagram/exception/NicknameAlreadyExistsException.java
+++ b/src/main/java/com/gxdxx/instagram/exception/NicknameAlreadyExistsException.java
@@ -1,0 +1,4 @@
+package com.gxdxx.instagram.exception;
+
+public class NicknameAlreadyExistsException extends RuntimeException {
+}

--- a/src/main/java/com/gxdxx/instagram/exception/UserNotFoundException.java
+++ b/src/main/java/com/gxdxx/instagram/exception/UserNotFoundException.java
@@ -1,0 +1,4 @@
+package com.gxdxx.instagram.exception;
+
+public class UserNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/gxdxx/instagram/repository/UserRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/gxdxx/instagram/repository/UserRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/UserRepository.java
@@ -3,5 +3,10 @@ package com.gxdxx.instagram.repository;
 import com.gxdxx.instagram.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByNickname(String nickname);
+
 }

--- a/src/main/java/com/gxdxx/instagram/service/UserService.java
+++ b/src/main/java/com/gxdxx/instagram/service/UserService.java
@@ -1,5 +1,9 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.UserSignUpRequest;
+import com.gxdxx.instagram.dto.response.UserSignUpResponse;
+import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
 import com.gxdxx.instagram.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -11,5 +15,20 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    public UserSignUpResponse saveUser(UserSignUpRequest request) {
+        userRepository.findByNickname(request.nickname()).ifPresent(user -> {
+            throw new NicknameAlreadyExistsException();
+        });
+        
+        // TODO: 파일업로드 구현하기
+        String profileImageUrl = new StringBuffer()
+                .append("http://example.com/images/.jpg")
+                .insert(26, request.nickname())
+                .toString();
+
+        User saveUser = User.of(request.nickname(), profileImageUrl);
+        return UserSignUpResponse.of(userRepository.save(saveUser));
+    }
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/UserService.java
+++ b/src/main/java/com/gxdxx/instagram/service/UserService.java
@@ -1,0 +1,15 @@
+package com.gxdxx.instagram.service;
+
+import com.gxdxx.instagram.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+}

--- a/src/main/java/com/gxdxx/instagram/service/UserService.java
+++ b/src/main/java/com/gxdxx/instagram/service/UserService.java
@@ -1,9 +1,11 @@
 package com.gxdxx.instagram.service;
 
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
+import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,13 @@ public class UserService {
 
         User saveUser = User.of(request.nickname(), profileImageUrl);
         return UserSignUpResponse.of(userRepository.save(saveUser));
+    }
+
+    public SuccessResponse deleteUser(Long id) {
+        // TODO: 본인이 맞는지 확인
+        User deleteUser = userRepository.findById(id).orElseThrow(UserNotFoundException::new);
+        userRepository.delete(deleteUser);
+        return SuccessResponse.of("회원탈퇴를 성공했습니다.");
     }
 
 }


### PR DESCRIPTION
## 작업 주제
- 회원 도메인 설계
- 회원가입 기능 구현
- 회원탈퇴 기능 구현
## 작업 내용
### 회원가입 기능
- 회원가입시 전송한 닉네임이 이미 가입돼있으면 예외가 발생하도록 처리했습니다.
- 이미지 업로드 기능은 S3에 업로드하도록 기능을 구현할 것입니다. 현재는 DB에 임의의 url 값만 저장하고 있습니다.
### 회원탈퇴 기능
- 회원탈퇴시 soft delete를 적용했습니다.
  - User 엔티티에 deleted 필드를 두어 삭제 요청시 deleted를 true로 변경하고, 
  - 조회하는 쿼리가 발생할 때 deleted가 false인 데이터만 조회하도록 구현했습니다.
- 아직 JWT를 적용하지 않아 요청한 유저와 삭제하려는 유저가 같은지 검증하는 로직은 추가하지 않았습니다.

This closes #1 