### PR TITLE
팔로우 도메인 설계

### DIFF
--- a/src/main/java/com/gxdxx/instagram/controller/FollowController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/FollowController.java
@@ -1,0 +1,15 @@
+package com.gxdxx.instagram.controller;
+
+import com.gxdxx.instagram.service.FollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/follows")
+@RestController
+public class FollowController {
+
+    private final FollowService followService;
+
+}

--- a/src/main/java/com/gxdxx/instagram/entity/Follow.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Follow.java
@@ -1,0 +1,51 @@
+package com.gxdxx.instagram.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.Objects;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "follower_id")
+    private User follower;
+
+    @ManyToOne
+    @JoinColumn(name = "following_id")
+    private User following;
+
+    private Follow(User follower, User following) {
+        this.follower = follower;
+        this.following = following;
+    }
+
+    public static Follow of(User follower, User following) {
+        return new Follow(follower, following);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Follow follow)) return false;
+        return id != null && id.equals(follow.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+
+}

--- a/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
@@ -1,0 +1,7 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+}

--- a/src/main/java/com/gxdxx/instagram/service/FollowService.java
+++ b/src/main/java/com/gxdxx/instagram/service/FollowService.java
@@ -1,0 +1,15 @@
+package com.gxdxx.instagram.service;
+
+import com.gxdxx.instagram.repository.FollowRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class FollowService {
+
+    private final FollowRepository followRepository;
+
+}


### PR DESCRIPTION
## 작업 주제
- 팔로우 도메인 설계
- 팔로우 Controller, Service, Repository 생성 및 초기 설
## 작업 내용
- 회원들간의 팔로우 기능을 구현하기 위해 팔로우 도메인을 설계했습니다.
- Follow 엔티티는 User 타입의 follower와 following 필드를 갖고 있으며, 각각 팔로우를 하는 사람과 팔로우를 당하는 사람을 나타냅니다.
- of 메서드는 follower와 following 객체를 전달받아 팔로우 객체를 생성하여 반환합니다.
- equals와 hashCode 메서드는 객체의 동등성 비교를 위해 오버라이딩 합니다. 여기서는 id 필드를 기준으로 비교합니다.

This closes #5 