### PR TITLE
팔로우 취소 기능 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
+++ b/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
@@ -28,6 +28,11 @@ public class RestControllerExceptionAdvice {
         return new ErrorResponse("이미 팔로우되어 있습니다.");
     }
 
+    @ExceptionHandler(FollowNotFountException.class)
+    public ErrorResponse followNotFountException(FollowNotFountException ex) {
+        return new ErrorResponse("존재하지 않는 팔로우입니다.");
+    }
+
     @ExceptionHandler(AuthorizationException.class)
     public ErrorResponse authorizationException(AuthorizationException ex) {
         return new ErrorResponse("권한이 없습니다.");

--- a/src/main/java/com/gxdxx/instagram/controller/FollowController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/FollowController.java
@@ -7,10 +7,7 @@ import com.gxdxx.instagram.service.FollowService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -33,6 +30,11 @@ public class FollowController {
         }
 
         return followService.createFollow(request, principal.getName());
+    }
+
+    @DeleteMapping("/{id}")
+    public SuccessResponse deleteFollow(@PathVariable("id") Long id, Principal principal) {
+        return followService.deleteFollow(id, principal.getName());
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/entity/Follow.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Follow.java
@@ -53,5 +53,8 @@ public class Follow {
         return Objects.hash(id);
     }
 
+    public void changeDeleted(boolean status) {
+        this.deleted = status;
+    }
 
 }

--- a/src/main/java/com/gxdxx/instagram/entity/Follow.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Follow.java
@@ -5,12 +5,16 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.Objects;
 
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE follow SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 @Entity
 public class Follow {
 
@@ -25,6 +29,8 @@ public class Follow {
     @ManyToOne
     @JoinColumn(name = "following_id")
     private User following;
+
+    private boolean deleted = Boolean.FALSE;
 
     private Follow(User follower, User following) {
         this.follower = follower;

--- a/src/main/java/com/gxdxx/instagram/entity/User.java
+++ b/src/main/java/com/gxdxx/instagram/entity/User.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE user SET deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE users SET deleted = true WHERE id = ?")
 @Where(clause = "deleted = false")
 @Table(name = "users")
 @Entity

--- a/src/main/java/com/gxdxx/instagram/exception/FollowNotFountException.java
+++ b/src/main/java/com/gxdxx/instagram/exception/FollowNotFountException.java
@@ -1,0 +1,4 @@
+package com.gxdxx.instagram.exception;
+
+public class FollowNotFountException extends RuntimeException {
+}

--- a/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.repository;
 
 import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
+import org.hibernate.annotations.Where;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,5 +12,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     boolean existsByFollowerAndFollowing(User follower, User following);
 
     Optional<Follow> findByFollowerAndFollowing(User follower, User following);
+
+    @Where(clause = "")
+    Optional<Follow> findByFollowerAndFollowingAndDeleted(User follower, User following, boolean status);
 
 }

--- a/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
@@ -4,8 +4,12 @@ import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByFollowerAndFollowing(User follower, User following);
+
+    Optional<Follow> findByFollowerAndFollowing(User follower, User following);
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/FollowService.java
+++ b/src/main/java/com/gxdxx/instagram/service/FollowService.java
@@ -5,6 +5,7 @@ import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.FollowAlreadyExistsException;
+import com.gxdxx.instagram.exception.FollowNotFountException;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.FollowRepository;
@@ -37,6 +38,19 @@ public class FollowService {
         }
 
         followRepository.save(Follow.createFollow(follower, following));
+        return SuccessResponse.of("200 SUCCESS");
+    }
+
+    public SuccessResponse deleteFollow(Long followingId, String followerNickname) {
+
+        User follower = userRepository.findByNickname(followerNickname)
+                .orElseThrow(UserNotFoundException::new);
+        User following = userRepository.findById(followingId)
+                .orElseThrow(UserNotFoundException::new);
+
+        Follow follow = followRepository.findByFollowerAndFollowing(follower, following)
+                .orElseThrow(FollowNotFountException::new);
+        followRepository.delete(follow);
         return SuccessResponse.of("200 SUCCESS");
     }
 

--- a/src/main/java/com/gxdxx/instagram/service/FollowService.java
+++ b/src/main/java/com/gxdxx/instagram/service/FollowService.java
@@ -37,7 +37,11 @@ public class FollowService {
             throw new FollowAlreadyExistsException();
         }
 
-        followRepository.save(Follow.createFollow(follower, following));
+        Follow follow = followRepository.findByFollowerAndFollowingAndDeleted(follower, following, true)
+                .orElse(Follow.createFollow(follower, following));
+        follow.changeDeleted(false);
+
+        followRepository.save(follow);
         return SuccessResponse.of("200 SUCCESS");
     }
 


### PR DESCRIPTION
## 작업 주제
- 팔로우 취소 기능 구현
## 작업 내용
- 팔로우 취소 시 soft delete가 되도록 구현했습니다.
- 취소된 팔로우를 다시 요청할 경우 update문이 동작하고, 
- 그렇지 않으면 insert문이 동작하도록 팔로우 요청 기능을 수정했습니다.

This closes #9 