### PR TITLE
프로필 조회 기능 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -3,6 +3,7 @@ package com.gxdxx.instagram.controller;
 import com.gxdxx.instagram.dto.request.UserLoginRequest;
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
+import com.gxdxx.instagram.dto.response.UserProfileResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.service.UserService;
@@ -48,6 +49,11 @@ public class UserController {
             throw new InvalidRequestException();
         }
         return userService.login(request, response);
+    }
+    
+    @GetMapping("/profile")
+    public UserProfileResponse getProfile(Principal principal) {
+        return userService.getProfile(principal);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/UserProfileResponse.java
@@ -1,0 +1,16 @@
+package com.gxdxx.instagram.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserProfileResponse(
+        @JsonProperty("nickname") String nickname,
+        @JsonProperty("profile_image_url") String profileImageUrl,
+        @JsonProperty("follower") Long follower,
+        @JsonProperty("following") Long following
+) {
+
+    public static UserProfileResponse of(String nickname, String profileImageUrl, Long follower, Long following) {
+        return new UserProfileResponse(nickname, profileImageUrl, follower, following);
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/FollowRepository.java
@@ -16,4 +16,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Where(clause = "")
     Optional<Follow> findByFollowerAndFollowingAndDeleted(User follower, User following, boolean status);
 
+    Long countByFollower(User follower);
+
+    Long countByFollowing(User following);
+
 }


### PR DESCRIPTION
## 작업 주제
- 프로필 조회 기능 구현

## 작업 내용
- 팔로워 수, 팔로잉 수를 조회하기 위해 쿼리 메소드를 구현했습니다.
- 매번 팔로워 수, 팔로잉 수를 DB에서 조회하는 경우 DB에 부하가 많이 걸리게 되어 성능 문제가 발생할 수 있습니다. 하지만 팔로워 수, 팔로잉 수를 User 엔티티에 저장하는 경우 변경이 일어날 때마다 해당 값을 업데이트해주는 작업이 필요합니다. 현재 구현에서는 변경점을 줄이는 것을 우선시하여 프로필 조회시마다 DB에서 조회하도록 구현하였습니다. DB 부하에 의한 성능 문제를 해결하기 위해 Redis를 사용하는 것을 고려하고 있습니다.

This closes #11 