### PR TITLE
프로필 수정 기능 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,9 +1,11 @@
 package com.gxdxx.instagram.controller;
 
 import com.gxdxx.instagram.dto.request.UserLoginRequest;
+import com.gxdxx.instagram.dto.request.UserProfileUpdateRequest;
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserProfileResponse;
+import com.gxdxx.instagram.dto.response.UserProfileUpdateResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.service.UserService;
@@ -54,6 +56,18 @@ public class UserController {
     @GetMapping("/profile")
     public UserProfileResponse getProfile(Principal principal) {
         return userService.getProfile(principal);
+    }
+
+    @PutMapping("/profile")
+    public UserProfileUpdateResponse updateProfile(
+            @Valid UserProfileUpdateRequest request,
+            BindingResult bindingResult,
+            Principal principal
+    ) {
+        if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+        return userService.updateProfile(request, principal);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserProfileUpdateRequest.java
@@ -2,10 +2,11 @@ package com.gxdxx.instagram.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 public record UserProfileUpdateRequest(
         @JsonProperty("nickname") @NotBlank String nickname,
-        @JsonProperty("profile_image") MultipartFile profileImage
+        @JsonProperty("profile_image") @NotNull MultipartFile profileImage
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.gxdxx.instagram.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
+
+public record UserProfileUpdateRequest(
+        @JsonProperty("nickname") @NotBlank String nickname,
+        @JsonProperty("profile_image") MultipartFile profileImage
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/UserProfileUpdateResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/UserProfileUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.gxdxx.instagram.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record UserProfileUpdateResponse(
+        @JsonProperty("id") Long id,
+        @JsonProperty("nickname") String nickname,
+        @JsonProperty("profile_image_url") String profileImageUrl
+) {
+
+    public static UserProfileUpdateResponse of(Long id, String nickname, String profileImageUrl) {
+        return new UserProfileUpdateResponse(id, nickname, profileImageUrl);
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/entity/User.java
+++ b/src/main/java/com/gxdxx/instagram/entity/User.java
@@ -45,6 +45,11 @@ public class User {
         return new User(nickname, password, profileImageUrl);
     }
 
+    public void updateProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/gxdxx/instagram/service/UserService.java
+++ b/src/main/java/com/gxdxx/instagram/service/UserService.java
@@ -1,9 +1,11 @@
 package com.gxdxx.instagram.service;
 
 import com.gxdxx.instagram.dto.request.UserLoginRequest;
+import com.gxdxx.instagram.dto.request.UserProfileUpdateRequest;
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserProfileResponse;
+import com.gxdxx.instagram.dto.response.UserProfileUpdateResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.entity.RefreshToken;
 import com.gxdxx.instagram.entity.User;
@@ -68,6 +70,19 @@ public class UserService {
         Long followerCount = followRepository.countByFollowing(user);
         Long followingCount = followRepository.countByFollower(user);
         return UserProfileResponse.of(user.getNickname(), user.getProfileImageUrl(), followerCount, followingCount);
+    }
+
+    public UserProfileUpdateResponse updateProfile(UserProfileUpdateRequest request, Principal principal) {
+        User user = getUserFromPrincipal(principal);
+
+        // TODO: 파일업로드 구현하기
+        String profileImageUrl = new StringBuffer()
+                .append("http://example.com/images/.jpg")
+                .insert(26, request.nickname())
+                .toString();
+
+        user.updateProfile(request.nickname(), profileImageUrl);
+        return UserProfileUpdateResponse.of(user.getId(), user.getNickname(), user.getProfileImageUrl());
     }
 
     private User getUserFromPrincipal(Principal principal) {


### PR DESCRIPTION
## 작업 주제
- 프로필 수정 기능 구현
## 작업 내용
- PUT 요청으로 닉네임, 프로필 이미지를 전달받아 로그인한 회원의 닉네임, 프로필 이미지 url을 변경합니다.
- 현재는 파일 업로드 기능을 구현하지 않은 상태여서 임의의 url을 저장하고 있습니다.

This closes #13 