### PR TITLE
AWS S3에 이미지 업로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/gxdxx/instagram/config/S3Config.java
+++ b/src/main/java/com/gxdxx/instagram/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.gxdxx.instagram.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.security.Principal;
 
 @RequiredArgsConstructor
@@ -29,7 +30,7 @@ public class UserController {
     public UserSignUpResponse registerUser(
             @Valid UserSignUpRequest request,
             BindingResult bindingResult
-    ) {
+    ) throws IOException {
         if (bindingResult.hasErrors()) {
             throw new InvalidRequestException();
         }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserSignUpRequest.java
@@ -1,7 +1,13 @@
 package com.gxdxx.instagram.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
-public record UserSignUpRequest(@NotBlank String nickname, @NotBlank String password, MultipartFile profileImage) {
+public record UserSignUpRequest(
+        @NotBlank String nickname,
+        @NotBlank String password,
+        @RequestPart(value = "profile_image") @NotNull MultipartFile profileImage
+) {
 }

--- a/src/main/java/com/gxdxx/instagram/service/S3Uploader.java
+++ b/src/main/java/com/gxdxx/instagram/service/S3Uploader.java
@@ -1,0 +1,69 @@
+package com.gxdxx.instagram.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File 전환 실패"));
+        String uploadImageUrl = putS3(uploadFile, dirName);
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String dirName) {
+        String fileName = generateFileName(uploadFile.getName(), dirName);
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));// PublicRead 권한으로 업로드 됨
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    private String generateFileName(String originalFileName, String dirName) {
+        String ext = extractExtension(originalFileName);
+        return dirName + "/" + UUID.randomUUID() + "." + ext;
+    }
+
+    private String extractExtension(String originalFileName) {
+        int index = originalFileName.lastIndexOf(".");
+        return originalFileName.substring(index + 1);
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(file.getOriginalFilename());
+        if (convertFile.createNewFile()) {
+            file.transferTo(convertFile);
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+
+}


### PR DESCRIPTION
## 작업 주제
- AWS S3에 업로드 위한 설정
- AWS S3에 업로드 기능 구현
- 회원가입 시 업로드 작동하도록 수정
## 작업 내용
- 기존에 회원가입 시 프로필 이미지를 전달받아 임의의 url만 DB에 저장하던 것을 S3에 업로드하는 것으로 수정했습니다.
- @Value 어노테이션을 사용하여 application.yml파일에서 인증 정보와 지역 정보 값을 읽어오게 했습니다.
- 파일 이름은 UUID와 파일 확장자를 조합하여 저장하도록 했습니다.

This closes #15 