### PR TITLE
회원가입 비즈니스 로직 단위테스트 작성

### DIFF
--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -72,4 +72,21 @@ class UserServiceTest {
         assertEquals(storedFileName, response.profileImageUrl());
     }
 
+    @Test
+    @DisplayName("이미 존재하는 닉네임이면 회원가입에 실패한다.")
+    void saveUser_withExistingNickname_shouldThrowException() {
+        // given
+        String existingNickname = "existingNickname";
+        String password = "password";
+        String encodedPassword = "encodedPassword";
+        String storedFileName = "storedFileName";
+        MockMultipartFile mockFile = getMockMultipartFile();
+        UserSignUpRequest request = new UserSignUpRequest(existingNickname, password, mockFile);
+        User existingUser = User.of(existingNickname, encodedPassword, storedFileName);
+        when(userRepository.findByNickname(existingNickname)).thenReturn(Optional.of(existingUser));
+
+        // when & then
+        assertThrows(NicknameAlreadyExistsException.class, () -> userService.saveUser(request));
+    }
+
 }

--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -51,12 +51,7 @@ class UserServiceTest {
         String password = "password";
         String encodedPassword = "encodedPassword";
         String storedFileName = "storedFileName";
-        MockMultipartFile mockFile = new MockMultipartFile(
-                "file",
-                "test.png",
-                "image/png",
-                "test content".getBytes()
-        );
+        MockMultipartFile mockFile = getMockMultipartFile();
         UserSignUpRequest request = new UserSignUpRequest(nickname, password, mockFile);
         when(userRepository.findByNickname(anyString())).thenReturn(Optional.empty());
         when(s3Uploader.upload(any(), anyString())).thenReturn(storedFileName);
@@ -67,7 +62,6 @@ class UserServiceTest {
         UserSignUpResponse response = userService.saveUser(request);
 
         // then
-        assertNotNull(response);
         assertEquals(nickname, response.nickname());
         assertEquals(storedFileName, response.profileImageUrl());
     }
@@ -87,6 +81,16 @@ class UserServiceTest {
 
         // when & then
         assertThrows(NicknameAlreadyExistsException.class, () -> userService.saveUser(request));
+    }
+
+    private MockMultipartFile getMockMultipartFile() {
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.png",
+                "image/png",
+                "test content".getBytes()
+        );
+        return mockFile;
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -1,0 +1,25 @@
+package com.gxdxx.instagram.service;
+
+import com.gxdxx.instagram.repository.UserRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private S3Uploader s3Uploader;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    
+
+}

--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -1,25 +1,75 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.UserSignUpRequest;
+import com.gxdxx.instagram.dto.response.UserSignUpResponse;
+import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
+import com.gxdxx.instagram.jwt.JwtUtil;
+import com.gxdxx.instagram.repository.FollowRepository;
+import com.gxdxx.instagram.repository.RefreshTokenRepository;
 import com.gxdxx.instagram.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.io.IOException;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
+    @InjectMocks
+    private UserService userService;
     @Mock
     private UserRepository userRepository;
-
+    @Mock
+    private FollowRepository followRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
     @Mock
     private S3Uploader s3Uploader;
-
+    @Mock
+    private JwtUtil jwtUtil;
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    
+    @Test
+    @DisplayName("유효한 요청이 오면 회원가입에 성공한다.")
+    void saveUser_withValidRequest_shouldSaveUser() throws IOException {
+        // given
+        String nickname = "nickname";
+        String password = "password";
+        String encodedPassword = "encodedPassword";
+        String storedFileName = "storedFileName";
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                "test.png",
+                "image/png",
+                "test content".getBytes()
+        );
+        UserSignUpRequest request = new UserSignUpRequest(nickname, password, mockFile);
+        when(userRepository.findByNickname(anyString())).thenReturn(Optional.empty());
+        when(s3Uploader.upload(any(), anyString())).thenReturn(storedFileName);
+        when(passwordEncoder.encode(anyString())).thenReturn(encodedPassword);
+        when(userRepository.save(any(User.class))).thenReturn(User.of(nickname, encodedPassword, storedFileName));
+
+        // when
+        UserSignUpResponse response = userService.saveUser(request);
+
+        // then
+        assertNotNull(response);
+        assertEquals(nickname, response.nickname());
+        assertEquals(storedFileName, response.profileImageUrl());
+    }
 
 }


### PR DESCRIPTION
## 작업 주제
- 회원가입 비즈니스 로직 단위테스트
## 작업 내용
- 회원가입이 성공하는 경우와 실패하는 경우의 테스트 코드를 작성했습니다.
- 실패하는 경우는 중복된 닉네임으로 회원가입 요청을 할 경우 NicknameAlreadyExistsException 예외를 발생시킵니다.

This closes #17 