### PR TITLE
회원 탈퇴 비즈니스 로직 단위 테스트 작성

### DIFF
--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -1,6 +1,7 @@
 package com.gxdxx.instagram.service;
 
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
@@ -91,6 +92,24 @@ class UserServiceTest {
                 "test content".getBytes()
         );
         return mockFile;
+    }
+
+
+    @Test
+    @DisplayName("회원 탈퇴 성공")
+    void deleteUser_success() {
+        Long userId = 1L;
+        String nickname = "nickname";
+        String encodedPassword = "encodedPassword";
+        String storedFileName = "storedFileName";
+        User deleteUser = User.of(nickname, encodedPassword, storedFileName);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(deleteUser));
+
+        SuccessResponse response = userService.deleteUser(userId, nickname);
+
+        assertEquals("회원탈퇴를 성공했습니다.", response.message());
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).delete(deleteUser);
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.gxdxx.instagram.dto.request.UserSignUpRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.AuthorizationException;
 import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.jwt.JwtUtil;
@@ -121,6 +122,23 @@ class UserServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         assertThrows(UserNotFoundException.class, () -> userService.deleteUser(userId, nickname));
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("[회원 탈퇴] - 실패 (인가되지 않은 회원)")
+    void deleteUser_authorizationFailed() {
+        Long userId = 1L;
+        String nickname = "nickname";
+        String wrongNickname = "wrongNickname";
+        String encodedPassword = "encodedPassword";
+        String storedFileName = "storedFileName";
+        User deleteUser = User.of(wrongNickname, encodedPassword, storedFileName);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(deleteUser));
+
+        assertThrows(AuthorizationException.class, () -> userService.deleteUser(userId, nickname));
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, never()).delete(any());
     }

--- a/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.dto.response.UserSignUpResponse;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
+import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.jwt.JwtUtil;
 import com.gxdxx.instagram.repository.FollowRepository;
 import com.gxdxx.instagram.repository.RefreshTokenRepository;
@@ -110,6 +111,18 @@ class UserServiceTest {
         assertEquals("회원탈퇴를 성공했습니다.", response.message());
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, times(1)).delete(deleteUser);
+    }
+
+    @Test
+    @DisplayName("[회원 탈퇴] - 실패 (존재하지 않는 회원)")
+    void deleteUser_userNotFound() {
+        Long userId = 1L;
+        String nickname = "nickname";
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.deleteUser(userId, nickname));
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, never()).delete(any());
     }
 
 }


### PR DESCRIPTION
## 작업 주제
- 회원 탈퇴 비즈니스 로직 단위테스트
## 작업 내용
- 회원 탈퇴가 성공하는 경우와 실패하는 경우의 테스트 코드를 작성했습니다.
- 존재하지 않는 회원으로 회원 탈퇴 요청을 할 경우 UserNotFoundException 예외를 발생시킵니다.
- 로그인한 회원과 탈퇴할 회원이 다를 경우 AuthorizationException 예외를 발생시킵니다.

This closes #19 