### PR TITLE
피드 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
     mavenCentral()
 }
 
+def queryDslVersion = '5.0.0'
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -36,6 +38,10 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+
+    implementation("com.querydsl:querydsl-core:${queryDslVersion}")
+    implementation("com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:${queryDslVersion}:jakarta", "jakarta.persistence:jakarta.persistence-api:3.1.0")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gxdxx/instagram/config/JpaConfig.java
+++ b/src/main/java/com/gxdxx/instagram/config/JpaConfig.java
@@ -1,5 +1,8 @@
 package com.gxdxx.instagram.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -14,6 +17,17 @@ public class JpaConfig {
     @Bean
     public AuditorAware<String> auditorAware() {
         return () -> Optional.of("for test");
+    }
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public JpaConfig() {
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(this.entityManager);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/controller/PostController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.PostFeedRequest;
 import com.gxdxx.instagram.dto.request.PostRegisterRequest;
 import com.gxdxx.instagram.dto.request.PostUpdateRequest;
 import com.gxdxx.instagram.dto.response.PostRegisterResponse;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.security.Principal;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/posts")
@@ -53,5 +55,19 @@ public class PostController {
     ) {
         return postService.deletePost(id, principal.getName());
     }
+
+    @GetMapping("/{id}/feed")
+    public Map<String, Object> getFeed(
+            @RequestBody @Valid PostFeedRequest request,
+            BindingResult bindingResult,
+            Principal principal
+    ) {
+        if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+
+        return postService.getFeed(request, principal.getName());
+    }
+
 
 }

--- a/src/main/java/com/gxdxx/instagram/controller/ReplyController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/ReplyController.java
@@ -10,10 +10,7 @@ import com.gxdxx.instagram.service.ReplyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
@@ -24,6 +21,7 @@ public class ReplyController {
 
     private final ReplyService replyService;
 
+    @PostMapping
     public ReplyRegisterResponse registerReply(
             @RequestBody @Valid ReplyRegisterRequest request,
             BindingResult bindingResult,
@@ -35,6 +33,7 @@ public class ReplyController {
         return replyService.registerReply(request, principal.getName());
     }
 
+    @PutMapping("/{id}")
     public ReplyUpdateResponse updateReply(
             @RequestBody @Valid ReplyUpdateRequest request,
             BindingResult bindingResult,
@@ -46,6 +45,7 @@ public class ReplyController {
         return replyService.updateReply(request, principal.getName());
     }
 
+    @DeleteMapping("/{id}")
     public SuccessResponse deleteReply(
             @PathVariable("id") Long id,
             Principal principal

--- a/src/main/java/com/gxdxx/instagram/dto/request/PostFeedRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/PostFeedRequest.java
@@ -1,0 +1,9 @@
+package com.gxdxx.instagram.dto.request;
+
+import jakarta.validation.constraints.Positive;
+
+public record PostFeedRequest(
+        @Positive Long userId,
+        Long cursor
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/PostFeedResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/PostFeedResponse.java
@@ -1,0 +1,38 @@
+package com.gxdxx.instagram.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostFeedResponse {
+
+    @JsonProperty("post_id")
+    public Long postId;
+
+    @JsonProperty("content")
+    public String content;
+
+    @JsonProperty("image_url")
+    public String imageUrl;
+
+    @JsonProperty("user_id")
+    public Long userId;
+
+    @JsonProperty("nickname")
+    public String nickname;
+
+    @QueryProjection
+    public PostFeedResponse(Long postId, String content, String imageUrl, Long userId, String nickname) {
+        this.postId = postId;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.userId = userId;
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/entity/Comment.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Comment.java
@@ -28,11 +28,11 @@ public class Comment {
 
     private boolean deleted = Boolean.FALSE;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/gxdxx/instagram/entity/Follow.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Follow.java
@@ -22,11 +22,11 @@ public class Follow {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id")
     private User follower;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id")
     private User following;
 

--- a/src/main/java/com/gxdxx/instagram/entity/Post.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Post.java
@@ -30,7 +30,7 @@ public class Post {
 
     private boolean deleted = Boolean.FALSE;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/gxdxx/instagram/entity/Reply.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Reply.java
@@ -28,11 +28,11 @@ public class Reply {
 
     private boolean deleted = Boolean.FALSE;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
 

--- a/src/main/java/com/gxdxx/instagram/repository/PostRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/PostRepository.java
@@ -2,6 +2,13 @@ package com.gxdxx.instagram.repository;
 
 import com.gxdxx.instagram.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+
+    @Query("SELECT MAX(p.id) FROM Post p")
+    Optional<Long> findMaxPostId();
+
 }

--- a/src/main/java/com/gxdxx/instagram/repository/PostRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/PostRepository.java
@@ -3,5 +3,5 @@ package com.gxdxx.instagram.repository;
 import com.gxdxx.instagram.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/src/main/java/com/gxdxx/instagram/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/gxdxx/instagram/repository/PostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.dto.response.PostFeedResponse;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<PostFeedResponse> getPostsByCursor(Long requestingUserId, Long cursor, int limit);
+
+}

--- a/src/main/java/com/gxdxx/instagram/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/gxdxx/instagram/repository/PostRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.dto.response.PostFeedResponse;
+import com.gxdxx.instagram.dto.response.QPostFeedResponse;
+import com.gxdxx.instagram.entity.*;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<PostFeedResponse> getPostsByCursor(Long requestingUserId, Long cursor, int limit) {
+        QPost post = QPost.post;
+        QUser user = QUser.user;
+        QFollow follow = QFollow.follow;
+
+        List<Long> followings = jpaQueryFactory
+                .select(follow.following.id)
+                .from(follow)
+                .where(follow.follower.id.eq(requestingUserId))
+                .fetch();
+
+        List<PostFeedResponse> postsQuery = jpaQueryFactory
+                .select(new QPostFeedResponse(post.id, post.content, post.imageUrl, user.id, user.nickname))
+                .from(post)
+                .join(post.user, user)
+                .on(post.user.id.in(followings))
+                .where(post.id.lt(cursor))
+                .orderBy(post.id.desc())
+                .limit(limit)
+                .fetch();
+
+        return postsQuery;
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/service/PostService.java
+++ b/src/main/java/com/gxdxx/instagram/service/PostService.java
@@ -1,7 +1,9 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.PostFeedRequest;
 import com.gxdxx.instagram.dto.request.PostRegisterRequest;
 import com.gxdxx.instagram.dto.request.PostUpdateRequest;
+import com.gxdxx.instagram.dto.response.PostFeedResponse;
 import com.gxdxx.instagram.dto.response.PostRegisterResponse;
 import com.gxdxx.instagram.dto.response.PostUpdateResponse;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
@@ -17,6 +19,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Transactional
@@ -54,6 +59,18 @@ public class PostService {
         }
         postRepository.delete(deletingPost);
         return SuccessResponse.of("200 SUCCESS");
+    }
+
+    public Map<String, Object> getFeed(PostFeedRequest request, String requestingUserNickname) {
+        User user = userRepository.findByNickname(requestingUserNickname)
+                .orElseThrow(UserNotFoundException::new);
+        List<PostFeedResponse> feeds = postRepository.getPostsByCursor(user.getId(), request.cursor(), 5);
+        Long cursor = !feeds.isEmpty() ? feeds.get(0).getPostId() : 0L;
+        Map<String, Object> response = new HashMap<>();
+        response.put("cursor", cursor);
+        response.put("posts", feeds);
+
+        return response;
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/PostService.java
+++ b/src/main/java/com/gxdxx/instagram/service/PostService.java
@@ -64,10 +64,13 @@ public class PostService {
     public Map<String, Object> getFeed(PostFeedRequest request, String requestingUserNickname) {
         User user = userRepository.findByNickname(requestingUserNickname)
                 .orElseThrow(UserNotFoundException::new);
-        List<PostFeedResponse> feeds = postRepository.getPostsByCursor(user.getId(), request.cursor(), 5);
-        Long cursor = !feeds.isEmpty() ? feeds.get(feeds.size() - 1).getPostId() : 0L;
+        Long cursor = (request.cursor() == null)
+                ? postRepository.findMaxPostId().map(maxId -> maxId + 1).orElse(0L)
+                : request.cursor();
+        List<PostFeedResponse> feeds = postRepository.getPostsByCursor(user.getId(), cursor, 5);
+        Long nextCursor = !feeds.isEmpty() ? feeds.get(feeds.size() - 1).getPostId() : 0L;
         Map<String, Object> response = new HashMap<>();
-        response.put("cursor", cursor);
+        response.put("cursor", nextCursor);
         response.put("posts", feeds);
 
         return response;

--- a/src/main/java/com/gxdxx/instagram/service/PostService.java
+++ b/src/main/java/com/gxdxx/instagram/service/PostService.java
@@ -65,7 +65,7 @@ public class PostService {
         User user = userRepository.findByNickname(requestingUserNickname)
                 .orElseThrow(UserNotFoundException::new);
         List<PostFeedResponse> feeds = postRepository.getPostsByCursor(user.getId(), request.cursor(), 5);
-        Long cursor = !feeds.isEmpty() ? feeds.get(0).getPostId() : 0L;
+        Long cursor = !feeds.isEmpty() ? feeds.get(feeds.size() - 1).getPostId() : 0L;
         Map<String, Object> response = new HashMap<>();
         response.put("cursor", cursor);
         response.put("posts", feeds);


### PR DESCRIPTION
## 작업 주제
- QueryDSL 설정
- 피드 조회 기능 구현
## 작업 내용
- 피드 조회 쿼리를 작성하기 위해 QueryDSL 5.0을 설정했습니다.
- 팔로잉중인 회원의 게시글을 조회할 때 cursor 기반 페이지네이션을 적용했습니다.
- 요청값으로 cursor가 null일 경우, 가장 최근 게시글부터 일정값 만큼만 조회하도록 구현했습니다.
- 응답값으로 조회한 게시글과 게시글 목록의 가장 마지막 값의 id를 cursor값으로 전달합니다.

This closes #27 