### PR TITLE
DM 전송 기능 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/controller/MessageController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/MessageController.java
@@ -1,9 +1,18 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.MessageSendRequest;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
+import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.service.MessageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/messages")
@@ -11,5 +20,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class MessageController {
 
     private final MessageService messageService;
+
+    @PostMapping
+    public SuccessResponse sendMessage(
+            @RequestBody @Valid MessageSendRequest request,
+            BindingResult bindingResult,
+            Principal principal
+    ) {
+
+        if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+
+        return messageService.sendMessage(request, principal.getName());
+    }
 
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/MessageSendRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/MessageSendRequest.java
@@ -1,0 +1,11 @@
+package com.gxdxx.instagram.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record MessageSendRequest(
+        @JsonProperty("user_id") @Positive Long userId,
+        @NotBlank String content
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepository.java
@@ -2,6 +2,16 @@ package com.gxdxx.instagram.repository;
 
 import com.gxdxx.instagram.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("SELECT cr FROM ChatRoom cr " +
+            "WHERE (cr.userA.id = :senderId AND cr.userB.id = :receiverId) " +
+            "OR (cr.userA.id = :receiverId AND cr.userB.id = :senderId)")
+    Optional<ChatRoom> findByUserIds(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
+
 }

--- a/src/main/java/com/gxdxx/instagram/service/MessageService.java
+++ b/src/main/java/com/gxdxx/instagram/service/MessageService.java
@@ -1,6 +1,15 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.MessageSendRequest;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
+import com.gxdxx.instagram.entity.ChatRoom;
+import com.gxdxx.instagram.entity.Message;
+import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.InvalidRequestException;
+import com.gxdxx.instagram.exception.UserNotFoundException;
+import com.gxdxx.instagram.repository.ChatRoomRepository;
 import com.gxdxx.instagram.repository.MessageRepository;
+import com.gxdxx.instagram.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,5 +20,38 @@ import org.springframework.stereotype.Service;
 public class MessageService {
 
     private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public SuccessResponse sendMessage(MessageSendRequest request, String nickname) {
+        User sendUser = getUserByNickname(nickname);
+        User receiveUser = getUserById(request.userId());
+        validateUsers(sendUser, receiveUser);
+        ChatRoom chatRoom = getOrCreateChatRoom(sendUser, receiveUser);
+        Message message = Message.of(request.content(), chatRoom, sendUser, receiveUser);
+        messageRepository.save(message);
+        return SuccessResponse.of("200 SUCCESS");
+    }
+
+    private User getUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private void validateUsers(User sendUser, User receiveUser) {
+        if (sendUser.equals(receiveUser)) {
+            throw new InvalidRequestException();
+        }
+    }
+
+    private ChatRoom getOrCreateChatRoom(User sendUser, User receiveUser) {
+        return chatRoomRepository.findByUserIds(sendUser.getId(), receiveUser.getId())
+                .orElseGet(() -> chatRoomRepository.save(ChatRoom.of(sendUser, receiveUser)));
+    }
 
 }


### PR DESCRIPTION
## 작업 내용
- DM 전송 기능을 구현했습니다.
- 두 회원이 메시지를 교환한 적이 없으면 채팅방이 존재하지 않습니다. 그러므로 먼저 두 회원간의 채팅방을 조회할 때, 없을 경우 새로 생성해 DB에 저장하고 그 뒤에 메시지를 DB에 저장하는 로직을 구현했습니다.

This closes #33 