### PR TITLE
DM 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/controller/ChatRoomController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/ChatRoomController.java
@@ -1,11 +1,36 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.ChatRoomListRequest;
+import com.gxdxx.instagram.exception.InvalidRequestException;
+import com.gxdxx.instagram.service.ChatRoomService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/chat-rooms")
 @RestController
 public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping
+    public Map<String, Object> getChatRooms(
+            @RequestBody @Valid ChatRoomListRequest request,
+            BindingResult bindingResult,
+            Principal principal
+    ) {
+        if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+        return chatRoomService.getChatRooms(request, principal.getName());
+    }
+
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/ChatRoomListRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/ChatRoomListRequest.java
@@ -1,0 +1,6 @@
+package com.gxdxx.instagram.dto.request;
+
+public record ChatRoomListRequest(
+        Long cursor
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,41 @@
+package com.gxdxx.instagram.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChatRoomListResponse {
+
+    @JsonProperty("chat_room_id")
+    public Long chatRoomId;
+
+    @JsonProperty("nickname")
+    public String nickname;
+
+    @JsonProperty("profile_image_url")
+    public String profileImageUrl;
+
+    @JsonProperty("last_message")
+    public String lastMessage;
+
+    @JsonProperty("last_sent_at")
+    public LocalDateTime lastSentAt;
+
+
+    @QueryProjection
+    public ChatRoomListResponse(Long chatRoomId, String nickname, String profileImageUrl, String lastMessage, LocalDateTime lastSentAt) {
+        this.chatRoomId = chatRoomId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.lastMessage = lastMessage;
+        this.lastSentAt = lastSentAt;
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/entity/ChatRoom.java
+++ b/src/main/java/com/gxdxx/instagram/entity/ChatRoom.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
@@ -30,6 +31,10 @@ public class ChatRoom {
     @JoinColumn(name = "user_b_id")
     private User userB;
 
+    private String lastMessage;
+
+    private LocalDateTime lastSentAt;
+
     private boolean deleted = Boolean.FALSE;
 
     private ChatRoom(User userA, User userB) {
@@ -39,6 +44,11 @@ public class ChatRoom {
 
     public static ChatRoom of(User userA, User userB) {
         return new ChatRoom(userA, userB);
+    }
+
+    public void updateLastMessage(String lastMessage, LocalDateTime lastSentAt) {
+        this.lastMessage = lastMessage;
+        this.lastSentAt = lastSentAt;
     }
 
     @Override

--- a/src/main/java/com/gxdxx/instagram/entity/Message.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Message.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
@@ -36,17 +37,20 @@ public class Message {
     @JoinColumn(name = "receiver_id")
     private User receiver;
 
+    private LocalDateTime sentAt;
+
     private boolean deleted = Boolean.FALSE;
 
-    private Message(String content, ChatRoom chatRoom, User sender, User receiver) {
+    private Message(String content, ChatRoom chatRoom, User sender, User receiver, LocalDateTime sentAt) {
         this.content = content;
         this.chatRoom = chatRoom;
         this.sender = sender;
         this.receiver = receiver;
+        this.sentAt = sentAt;
     }
 
-    public static Message of(String content, ChatRoom chatRoom, User sender, User receiver) {
-        return new Message(content, chatRoom, sender, receiver);
+    public static Message of(String content, ChatRoom chatRoom, User sender, User receiver, LocalDateTime sentAt) {
+        return new Message(content, chatRoom, sender, receiver, sentAt);
     }
 
     @Override

--- a/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepository.java
@@ -7,11 +7,14 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, ChatRoomRepositoryCustom {
 
     @Query("SELECT cr FROM ChatRoom cr " +
             "WHERE (cr.userA.id = :senderId AND cr.userB.id = :receiverId) " +
             "OR (cr.userA.id = :receiverId AND cr.userB.id = :senderId)")
     Optional<ChatRoom> findByUserIds(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
+
+    @Query("SELECT MAX(cr.id) FROM ChatRoom cr")
+    Optional<Long> findMaxChatRoomId();
 
 }

--- a/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.dto.response.ChatRoomListResponse;
+
+import java.util.List;
+
+public interface ChatRoomRepositoryCustom {
+
+    List<ChatRoomListResponse> getChatRoomsByCursor(Long requestingUserId, Long cursor, int limit);
+
+}

--- a/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/gxdxx/instagram/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,58 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.dto.response.ChatRoomListResponse;
+import com.gxdxx.instagram.dto.response.QChatRoomListResponse;
+import com.gxdxx.instagram.entity.QChatRoom;
+import com.gxdxx.instagram.entity.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<ChatRoomListResponse> getChatRoomsByCursor(Long requestingUserId, Long cursor, int limit) {
+        QUser userA = new QUser("userA");
+        QUser userB = new QUser("userB");
+        QChatRoom chatRoom = QChatRoom.chatRoom;
+
+        List<Long> chatIds = jpaQueryFactory
+                .select(chatRoom.id)
+                .from(chatRoom)
+                .where(
+                        chatRoom.userA.id.eq(requestingUserId).or(chatRoom.userB.id.eq(requestingUserId))
+                )
+                .where(chatRoom.id.lt(cursor))
+                .orderBy(chatRoom.id.desc())
+                .limit(limit)
+                .fetch();
+
+        BooleanBuilder userANotRequestingUserId = new BooleanBuilder();
+        userANotRequestingUserId.and(chatRoom.userA.id.eq(requestingUserId).not());
+
+        BooleanBuilder userBNotRequestingUserId = new BooleanBuilder();
+        userBNotRequestingUserId.and(chatRoom.userB.id.eq(requestingUserId).not());
+
+        return jpaQueryFactory
+                .select(new QChatRoomListResponse(chatRoom.id,
+                        new CaseBuilder().when(userANotRequestingUserId).then(userA.nickname).otherwise(userB.nickname),
+                        new CaseBuilder().when(userANotRequestingUserId).then(userA.profileImageUrl).otherwise(userB.profileImageUrl),
+                        chatRoom.lastMessage,
+                        chatRoom.lastSentAt))
+                .from(chatRoom)
+                .join(chatRoom.userA, userA)
+                .join(chatRoom.userB, userB)
+                .where(chatRoom.id.in(chatIds))
+                .orderBy(chatRoom.id.desc())
+                .fetch();
+    }
+
+
+}

--- a/src/main/java/com/gxdxx/instagram/service/ChatRoomService.java
+++ b/src/main/java/com/gxdxx/instagram/service/ChatRoomService.java
@@ -1,9 +1,18 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.ChatRoomListRequest;
+import com.gxdxx.instagram.dto.response.ChatRoomListResponse;
+import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.ChatRoomRepository;
+import com.gxdxx.instagram.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Transactional
@@ -11,5 +20,21 @@ import org.springframework.stereotype.Service;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+
+    public Map<String, Object> getChatRooms(ChatRoomListRequest request, String nickname) {
+        User user = userRepository.findByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+        Long cursor = (request.cursor() == null)
+                ? chatRoomRepository.findMaxChatRoomId().map(maxId -> maxId + 1).orElse(0L)
+                : request.cursor();
+        List<ChatRoomListResponse> list = chatRoomRepository.getChatRoomsByCursor(user.getId(), cursor, 5);
+        Long nextCursor = !list.isEmpty() ? list.get(list.size() - 1).getChatRoomId() : 0L;
+        Map<String, Object> response = new HashMap<>();
+        response.put("cursor", nextCursor);
+        response.put("chat_rooms", list);
+
+        return response;
+    }
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/MessageService.java
+++ b/src/main/java/com/gxdxx/instagram/service/MessageService.java
@@ -14,6 +14,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @Transactional
 @Service
@@ -28,7 +30,9 @@ public class MessageService {
         User receiveUser = getUserById(request.userId());
         validateUsers(sendUser, receiveUser);
         ChatRoom chatRoom = getOrCreateChatRoom(sendUser, receiveUser);
-        Message message = Message.of(request.content(), chatRoom, sendUser, receiveUser);
+        LocalDateTime now = LocalDateTime.now();
+        chatRoom.updateLastMessage(request.content(), now);
+        Message message = Message.of(request.content(), chatRoom, sendUser, receiveUser, now);
         messageRepository.save(message);
         return SuccessResponse.of("200 SUCCESS");
     }


### PR DESCRIPTION
## 작업 내용
- 기존 DM 전송 기능을 수정
  - 메시지 엔티티에 sentAt 필드를 추가했습니다.
  - 채팅방 엔티티에 lastMessage, lastSentAt 필드를 추가했습니다.
  - 메시지를 전송 시 해당 메시지가 속한 채팅방 엔티티의 lastMessage, lastSentAt 값을 수정하는 로직을 추가했습니다.
- DM 목록 조회 기능 구현
  - QueryDSL을 이용해 DM 목록 조회를 요청한 회원이 속한 채팅방의 리스트 중, cursor 값보다 작은 채팅방 ID를 가진 채팅방을 최대 limit 개수만큼 조회하는 기능을 구현했습니다.
  - join을 사용해 쿼리 결과를 한 번에 가져오도록 쿼리를 작성해 N+1 문제를 해결했습니다.

This closes #35 