### PR TITLE
DM 상세 내역 조회 기능 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
+++ b/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
@@ -53,6 +53,11 @@ public class RestControllerExceptionAdvice {
         return new ErrorResponse("존재하지 않는 답글입니다.");
     }
 
+    @ExceptionHandler(ChatRoomNotFoundException.class)
+    public ErrorResponse chatRoomNotFoundException(ChatRoomNotFoundException ex) {
+        return new ErrorResponse("존재하지 않는 채팅방입니다.");
+    }
+
     @ExceptionHandler(InvalidRequestException.class)
     public ErrorResponse invalidRequestException(InvalidRequestException ex) {
         return new ErrorResponse("입력값을 확인해주세요.");

--- a/src/main/java/com/gxdxx/instagram/controller/MessageController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/MessageController.java
@@ -1,5 +1,6 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.MessageListRequest;
 import com.gxdxx.instagram.dto.request.MessageSendRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.exception.InvalidRequestException;
@@ -7,12 +8,10 @@ import com.gxdxx.instagram.service.MessageService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/messages")
@@ -33,6 +32,20 @@ public class MessageController {
         }
 
         return messageService.sendMessage(request, principal.getName());
+    }
+
+    @GetMapping("/{chatRoomId}")
+    public Map<String, Object> getMessages(
+            @RequestBody @Valid MessageListRequest request,
+            BindingResult bindingResult,
+            Principal principal
+    ) {
+
+        if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+
+        return messageService.getMessages(request, principal.getName());
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/MessageListRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/MessageListRequest.java
@@ -1,0 +1,10 @@
+package com.gxdxx.instagram.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Positive;
+
+public record MessageListRequest(
+        @JsonProperty("chat_room_id") @Positive Long chatRoomId,
+        Long cursor
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/dto/response/MessageListResponse.java
+++ b/src/main/java/com/gxdxx/instagram/dto/response/MessageListResponse.java
@@ -1,0 +1,41 @@
+package com.gxdxx.instagram.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MessageListResponse {
+
+    @JsonProperty("message_id")
+    public Long messageId;
+
+    @JsonProperty("nickname")
+    public String nickname;
+
+    @JsonProperty("profile_image_url")
+    public String profileImageUrl;
+
+    @JsonProperty("content")
+    public String content;
+
+    @JsonProperty("sent_at")
+    public LocalDateTime sentAt;
+
+
+    @QueryProjection
+    public MessageListResponse(Long messageId, String nickname, String profileImageUrl, String content, LocalDateTime sentAt) {
+        this.messageId = messageId;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.content = content;
+        this.sentAt = sentAt;
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/entity/ChatRoom.java
+++ b/src/main/java/com/gxdxx/instagram/entity/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.gxdxx.instagram.entity;
 
+import com.gxdxx.instagram.exception.UnauthorizedAccessException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -49,6 +50,11 @@ public class ChatRoom {
     public void updateLastMessage(String lastMessage, LocalDateTime lastSentAt) {
         this.lastMessage = lastMessage;
         this.lastSentAt = lastSentAt;
+    }
+
+    public boolean hasUser(User requestUser) {
+        return this.getUserA().equals(requestUser) ||
+                this.getUserB().equals(requestUser);
     }
 
     @Override

--- a/src/main/java/com/gxdxx/instagram/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/gxdxx/instagram/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,4 @@
+package com.gxdxx.instagram.exception;
+
+public class ChatRoomNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/gxdxx/instagram/repository/MessageRepository.java
+++ b/src/main/java/com/gxdxx/instagram/repository/MessageRepository.java
@@ -2,6 +2,13 @@ package com.gxdxx.instagram.repository;
 
 import com.gxdxx.instagram.entity.Message;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface MessageRepository extends JpaRepository<Message, Long> {
+import java.util.Optional;
+
+public interface MessageRepository extends JpaRepository<Message, Long>, MessageRepositoryCustom {
+
+    @Query("SELECT MAX(m.id) FROM Message m")
+    Optional<Long> findMaxMessageId();
+
 }

--- a/src/main/java/com/gxdxx/instagram/repository/MessageRepositoryCustom.java
+++ b/src/main/java/com/gxdxx/instagram/repository/MessageRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.dto.response.ChatRoomListResponse;
+import com.gxdxx.instagram.dto.response.MessageListResponse;
+
+import java.util.List;
+
+public interface MessageRepositoryCustom {
+
+    List<MessageListResponse> getMessagesByCursor(Long requestingUserId, Long chatRoomId, Long cursor, int limit);
+
+}

--- a/src/main/java/com/gxdxx/instagram/repository/MessageRepositoryImpl.java
+++ b/src/main/java/com/gxdxx/instagram/repository/MessageRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.gxdxx.instagram.repository;
+
+import com.gxdxx.instagram.dto.response.MessageListResponse;
+import com.gxdxx.instagram.dto.response.QChatRoomListResponse;
+import com.gxdxx.instagram.dto.response.QMessageListResponse;
+import com.gxdxx.instagram.entity.QChatRoom;
+import com.gxdxx.instagram.entity.QMessage;
+import com.gxdxx.instagram.entity.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class MessageRepositoryImpl implements MessageRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<MessageListResponse> getMessagesByCursor(Long requestingUserId, Long chatRoomId, Long cursor, int limit) {
+        QUser sender = new QUser("sender");
+        QMessage message = QMessage.message;
+
+        List<Long> messageIds = jpaQueryFactory
+                .select(message.id)
+                .from(message)
+                .where(message.chatRoom.id.eq(chatRoomId))
+                .where(message.id.lt(cursor))
+                .orderBy(message.id.desc())
+                .limit(limit)
+                .fetch();
+
+        return jpaQueryFactory
+                .select(new QMessageListResponse(message.id, sender.nickname, sender.profileImageUrl, message.content, message.sentAt))
+                .from(message)
+                .join(message.sender, sender)
+                .where(message.id.in(messageIds))
+                .orderBy(message.id.desc())
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/service/MessageService.java
+++ b/src/main/java/com/gxdxx/instagram/service/MessageService.java
@@ -78,11 +78,8 @@ public class MessageService {
                 : request.cursor();
         List<MessageListResponse> messages = messageRepository.getMessagesByCursor(requestUser.getId(), chatRoom.getId(), cursor, 5);
         Long nextCursor = messages.isEmpty() ? 0L : messages.get(messages.size() - 1).getMessageId();
-        Map<String, Object> response = new HashMap<>();
-        response.put("cursor", nextCursor);
-        response.put("messages", messages);
 
-        return response;
+        return Map.of("cursor", nextCursor, "messages", messages);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/MessageService.java
+++ b/src/main/java/com/gxdxx/instagram/service/MessageService.java
@@ -70,7 +70,7 @@ public class MessageService {
         User requestUser = getUserByNickname(nickname);
         ChatRoom chatRoom = chatRoomRepository.findById(request.chatRoomId())
                 .orElseThrow(ChatRoomNotFoundException::new);
-        if (!chatRoom.getUserA().equals(requestUser) && !chatRoom.getUserB().equals(requestUser)) {
+        if (!chatRoom.hasUser(requestUser)) {
             throw new UnauthorizedAccessException();
         }
         Long cursor = (request.cursor() == null)

--- a/src/main/java/com/gxdxx/instagram/service/MessageService.java
+++ b/src/main/java/com/gxdxx/instagram/service/MessageService.java
@@ -1,11 +1,16 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.MessageListRequest;
 import com.gxdxx.instagram.dto.request.MessageSendRequest;
+import com.gxdxx.instagram.dto.response.ChatRoomListResponse;
+import com.gxdxx.instagram.dto.response.MessageListResponse;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.ChatRoom;
 import com.gxdxx.instagram.entity.Message;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.ChatRoomNotFoundException;
 import com.gxdxx.instagram.exception.InvalidRequestException;
+import com.gxdxx.instagram.exception.UnauthorizedAccessException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.ChatRoomRepository;
 import com.gxdxx.instagram.repository.MessageRepository;
@@ -15,6 +20,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Transactional
@@ -56,6 +64,25 @@ public class MessageService {
     private ChatRoom getOrCreateChatRoom(User sendUser, User receiveUser) {
         return chatRoomRepository.findByUserIds(sendUser.getId(), receiveUser.getId())
                 .orElseGet(() -> chatRoomRepository.save(ChatRoom.of(sendUser, receiveUser)));
+    }
+
+    public Map<String, Object> getMessages(MessageListRequest request, String nickname) {
+        User requestUser = getUserByNickname(nickname);
+        ChatRoom chatRoom = chatRoomRepository.findById(request.chatRoomId())
+                .orElseThrow(ChatRoomNotFoundException::new);
+        if (!chatRoom.getUserA().equals(requestUser) && !chatRoom.getUserB().equals(requestUser)) {
+            throw new UnauthorizedAccessException();
+        }
+        Long cursor = (request.cursor() == null)
+                ? messageRepository.findMaxMessageId().map(maxId -> maxId + 1).orElse(0L)
+                : request.cursor();
+        List<MessageListResponse> messages = messageRepository.getMessagesByCursor(requestUser.getId(), chatRoom.getId(), cursor, 5);
+        Long nextCursor = messages.isEmpty() ? 0L : messages.get(messages.size() - 1).getMessageId();
+        Map<String, Object> response = new HashMap<>();
+        response.put("cursor", nextCursor);
+        response.put("messages", messages);
+
+        return response;
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- DM 내역은 해당 DM이 속한 채팅방에 참여자만 조회할 수 있으므로 요청하는 회원이 해당 채팅방에 참여자인지 검증하는 로직을 구현했습니다.
- 요청 cursor 값이 null일 경우 가장 최근 메시지부터 조회를 시작합니다.
- 메시지를 조회 후 리스트가 비어있지 않다면, 다음 조회를 위해 마지막 MessageListResponse 객체의 MessageId 값을 다음 커서 값으로 응답에 전달합니다.
- 회원이 해당 채팅방에 참여자인지 검증하는 로직을 ChatRoom 엔티티에서 확인하도록 리팩토링하고 응답 객체 생성을 Map.of() 메소드를 이용해 간결하게 변경했습니다.

This closes #37 