### PR TITLE
팔로우 비즈니스 로직 단위 테스트 구현

### DIFF
--- a/src/main/java/com/gxdxx/instagram/service/FollowService.java
+++ b/src/main/java/com/gxdxx/instagram/service/FollowService.java
@@ -29,7 +29,7 @@ public class FollowService {
         User following = userRepository.findById(request.userId())
                 .orElseThrow(UserNotFoundException::new);
 
-        if (follower.getId() == following.getId()) {
+        if (follower.equals(following)) {
             throw new InvalidRequestException();
         }
 

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -1,13 +1,23 @@
 package com.gxdxx.instagram.service;
 
+import com.gxdxx.instagram.dto.request.FollowCreateRequest;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
+import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.repository.FollowRepository;
 import com.gxdxx.instagram.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class FollowServiceTest {
@@ -28,6 +38,23 @@ class FollowServiceTest {
     public void setUp() {
         follower = User.of("Follower", "password", "follower@example.com");
         following = User.of("Following", "password", "following@example.com");
+    }
+
+    @Test
+    @DisplayName("[팔로우] - 성공 (soft delete되었던 팔로우)")
+    public void createFollow_withSoftDeletedFollow_shouldCreateFollow() {
+        FollowCreateRequest request = new FollowCreateRequest(following.getId());
+        Follow softDeletedFollow = Follow.createFollow(follower, following);
+        softDeletedFollow.changeDeleted(true);
+
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
+        when(userRepository.findById(following.getId())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerAndFollowing(follower, following)).thenReturn(false);
+        when(followRepository.findByFollowerAndFollowingAndDeleted(follower, following, true)).thenReturn(Optional.of(softDeletedFollow));
+        when(followRepository.save(softDeletedFollow)).thenReturn(softDeletedFollow);
+
+        SuccessResponse response = followService.createFollow(request, follower.getNickname());
+        Assertions.assertEquals("200 SUCCESS", response.message());
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -4,6 +4,7 @@ import com.gxdxx.instagram.dto.request.FollowCreateRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.repository.FollowRepository;
 import com.gxdxx.instagram.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
@@ -72,6 +73,17 @@ class FollowServiceTest {
 
         SuccessResponse response = followService.createFollow(request, follower.getNickname());
         Assertions.assertEquals("200 SUCCESS", response.message());
+    }
+
+    @Test
+    @DisplayName("[팔로우] - 실패 (요청자와 팔로우할 유저가 같을 경우)")
+    public void createFollow_withSameUser_shouldFail() {
+        FollowCreateRequest request = new FollowCreateRequest(follower.getId());
+
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+
+        Assertions.assertThrows(InvalidRequestException.class, () -> followService.createFollow(request, follower.getNickname()));
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -46,7 +46,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("[팔로우] - 성공 (soft delete되었던 팔로우)")
-    public void createFollow_withSoftDeletedFollow_shouldCreateFollow() {
+    public void createFollow_withSoftDeletedFollow_shouldSucceed() {
         FollowCreateRequest request = new FollowCreateRequest(following.getId());
         Follow softDeletedFollow = Follow.createFollow(follower, following);
         softDeletedFollow.changeDeleted(true);
@@ -63,7 +63,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("[팔로우] - 성공 (soft delete되었던 적 없는 팔로우)")
-    public void createFollow_withoutSoftDelete_shouldCreateFollow() {
+    public void createFollow_withoutSoftDeletedFollow_shouldSucceed() {
         FollowCreateRequest request = new FollowCreateRequest(following.getId());
         Follow newFollow = Follow.createFollow(follower, following);
 
@@ -79,7 +79,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("[팔로우] - 실패 (요청자와 팔로우할 유저가 같을 경우)")
-    public void createFollow_withSameUser_shouldFail() {
+    public void createFollow_withSameUser_shouldThrowInvalidRequestException() {
         FollowCreateRequest request = new FollowCreateRequest(follower.getId());
 
         when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
@@ -90,7 +90,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("[팔로우] - 실패 (이미 존재하는 팔로우 관계일 경우)")
-    public void createFollow_withAlreadyExists_shouldFail() {
+    public void createFollow_withAlreadyExistsFollow_shouldThrowFollowAlreadyExistsException() {
         FollowCreateRequest request = new FollowCreateRequest(following.getId());
 
         when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
@@ -102,7 +102,7 @@ class FollowServiceTest {
 
     @Test
     @DisplayName("[팔로우] - 실패 (요청자 닉네임에 해당하는 유저가 존재하지 않는 경우)")
-    public void create_Follow_withFollowerNotFound_shouldFail() {
+    public void createFollow_withFollowerNotFound_shouldThrowUserNotFoundException() {
         FollowCreateRequest request = new FollowCreateRequest(following.getId());
 
         when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.empty());

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -6,6 +6,7 @@ import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.FollowAlreadyExistsException;
 import com.gxdxx.instagram.exception.InvalidRequestException;
+import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.FollowRepository;
 import com.gxdxx.instagram.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
@@ -97,6 +98,16 @@ class FollowServiceTest {
         when(followRepository.existsByFollowerAndFollowing(follower, following)).thenReturn(true);
 
         Assertions.assertThrows(FollowAlreadyExistsException.class, () -> followService.createFollow(request, follower.getNickname()));
+    }
+
+    @Test
+    @DisplayName("[팔로우] - 실패 (요청자 닉네임에 해당하는 유저가 존재하지 않는 경우)")
+    public void create_Follow_withFollowerNotFound_shouldFail() {
+        FollowCreateRequest request = new FollowCreateRequest(following.getId());
+
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(UserNotFoundException.class, () -> followService.createFollow(request, follower.getNickname()));
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -1,0 +1,33 @@
+package com.gxdxx.instagram.service;
+
+import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.repository.FollowRepository;
+import com.gxdxx.instagram.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @InjectMocks
+    private FollowService followService;
+
+    private User follower;
+    private User following;
+
+    @BeforeEach
+    public void setUp() {
+        follower = User.of("Follower", "password", "follower@example.com");
+        following = User.of("Following", "password", "following@example.com");
+    }
+
+}

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,6 +53,22 @@ class FollowServiceTest {
         when(followRepository.existsByFollowerAndFollowing(follower, following)).thenReturn(false);
         when(followRepository.findByFollowerAndFollowingAndDeleted(follower, following, true)).thenReturn(Optional.of(softDeletedFollow));
         when(followRepository.save(softDeletedFollow)).thenReturn(softDeletedFollow);
+
+        SuccessResponse response = followService.createFollow(request, follower.getNickname());
+        Assertions.assertEquals("200 SUCCESS", response.message());
+    }
+
+    @Test
+    @DisplayName("[팔로우] - 성공 (soft delete되었던 적 없는 팔로우)")
+    public void createFollow_withoutSoftDelete_shouldCreateFollow() {
+        FollowCreateRequest request = new FollowCreateRequest(following.getId());
+        Follow newFollow = Follow.createFollow(follower, following);
+
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
+        when(userRepository.findById(following.getId())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerAndFollowing(follower, following)).thenReturn(false);
+        when(followRepository.findByFollowerAndFollowingAndDeleted(follower, following, true)).thenReturn(Optional.empty());
+        when(followRepository.save(any())).thenReturn(newFollow);
 
         SuccessResponse response = followService.createFollow(request, follower.getNickname());
         Assertions.assertEquals("200 SUCCESS", response.message());

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -4,6 +4,7 @@ import com.gxdxx.instagram.dto.request.FollowCreateRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.FollowAlreadyExistsException;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.repository.FollowRepository;
 import com.gxdxx.instagram.repository.UserRepository;
@@ -84,6 +85,18 @@ class FollowServiceTest {
         when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
 
         Assertions.assertThrows(InvalidRequestException.class, () -> followService.createFollow(request, follower.getNickname()));
+    }
+
+    @Test
+    @DisplayName("[팔로우] - 실패 (이미 존재하는 팔로우 관계일 경우)")
+    public void createFollow_withAlreadyExists_shouldFail() {
+        FollowCreateRequest request = new FollowCreateRequest(following.getId());
+
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
+        when(userRepository.findById(following.getId())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerAndFollowing(follower, following)).thenReturn(true);
+
+        Assertions.assertThrows(FollowAlreadyExistsException.class, () -> followService.createFollow(request, follower.getNickname()));
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- 팔로우 성공 (soft delete되었던 팔로우일 경우)
- 팔로우 성공 (soft delete되었던 적 없는 경우)
- 팔로우 실패 (요청자와 팔로우할 유저가 같을 경우 예외 발생)
- 팔로우 실패 (이미 존재하는 팔로우 관계일 경우 예외 발생)
- 팔로우 실패 (요청자 닉네임에 해당하는 유저가 존재하지 않는 경우 예외 발생)

This closes #39 