### PR TITLE
팔로우 취소 비즈니스 로직 단위 테스트 구현

### DIFF
--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -138,4 +138,14 @@ class FollowServiceTest {
         Assertions.assertThrows(FollowNotFountException.class, () -> followService.deleteFollow(following.getId(), follower.getNickname()));
     }
 
+    @Test
+    @DisplayName("[팔로우 취소] - 실패 (요청자 닉네임에 해당하는 유저가 존재하지 않는 경우)")
+    public void deleteFollow_withNonExistingUser_shouldThrowUserNotFoundException() {
+        String nonExistingNickname = "non-existing-nickname";
+
+        when(userRepository.findByNickname(nonExistingNickname)).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(UserNotFoundException.class, () -> followService.deleteFollow(following.getId(), nonExistingNickname));
+    }
+
 }

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -108,6 +109,21 @@ class FollowServiceTest {
         when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.empty());
 
         Assertions.assertThrows(UserNotFoundException.class, () -> followService.createFollow(request, follower.getNickname()));
+    }
+
+    @Test
+    @DisplayName("[팔로우 취소] - 성공")
+    public void deleteFollow_shouldSucceed() {
+        Follow follow = Follow.createFollow(follower, following);
+
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
+        when(userRepository.findById(following.getId())).thenReturn(Optional.of(following));
+        when(followRepository.findByFollowerAndFollowing(follower, following)).thenReturn(Optional.of(follow));
+        doNothing().when(followRepository).delete(follow);
+
+        SuccessResponse response = followService.deleteFollow(following.getId(), follower.getNickname());
+
+        Assertions.assertEquals("200 SUCCESS", response.message());
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -5,6 +5,7 @@ import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.Follow;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.FollowAlreadyExistsException;
+import com.gxdxx.instagram.exception.FollowNotFountException;
 import com.gxdxx.instagram.exception.InvalidRequestException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.FollowRepository;
@@ -124,6 +125,17 @@ class FollowServiceTest {
         SuccessResponse response = followService.deleteFollow(following.getId(), follower.getNickname());
 
         Assertions.assertEquals("200 SUCCESS", response.message());
+    }
+
+    @Test
+    @DisplayName("[팔로우 취소] - 실패 (존재하지 않는 팔로우 관계)")
+    public void deleteFollow_withNonExistingFollow_shouldThrowFollowNotFoundException() {
+        
+        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.of(follower));
+        when(userRepository.findById(following.getId())).thenReturn(Optional.of(following));
+        when(followRepository.findByFollowerAndFollowing(follower, following)).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(FollowNotFountException.class, () -> followService.deleteFollow(following.getId(), follower.getNickname()));
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/FollowServiceTest.java
@@ -105,11 +105,12 @@ class FollowServiceTest {
     @Test
     @DisplayName("[팔로우] - 실패 (요청자 닉네임에 해당하는 유저가 존재하지 않는 경우)")
     public void createFollow_withFollowerNotFound_shouldThrowUserNotFoundException() {
+        String nonExistingNickname = "non-existing-nickname";
         FollowCreateRequest request = new FollowCreateRequest(following.getId());
 
-        when(userRepository.findByNickname(follower.getNickname())).thenReturn(Optional.empty());
+        when(userRepository.findByNickname(nonExistingNickname)).thenReturn(Optional.empty());
 
-        Assertions.assertThrows(UserNotFoundException.class, () -> followService.createFollow(request, follower.getNickname()));
+        Assertions.assertThrows(UserNotFoundException.class, () -> followService.createFollow(request, nonExistingNickname));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- 팔로우 취소 성공
- 팔로우 취소 실패 (팔로우 관계가 존재하지 않는 경우 예외 발생)
- 팔로우 취소 실패 (요청자 닉네임에 해당하는 유저가 존재하지 않는 경우 예외 발생)

This closes #41 