### PR TITLE
엔티티 유효성 검증 어노테이션 적용

### DIFF
--- a/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
+++ b/src/main/java/com/gxdxx/instagram/advice/RestControllerExceptionAdvice.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.advice;
 
 import com.gxdxx.instagram.dto.response.ErrorResponse;
 import com.gxdxx.instagram.exception.*;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -66,6 +67,11 @@ public class RestControllerExceptionAdvice {
     @ExceptionHandler(FileProcessingException.class)
     public ErrorResponse fileProcessingException(FileProcessingException ex) {
         return new ErrorResponse("파일 업로드 중 문제가 발생했습니다.");
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ErrorResponse constraintViolationException(ConstraintViolationException ex) {
+        return new ErrorResponse("문제가 발생했습니다. 관리자에게 문의해주세요.");
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/controller/PostController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/PostController.java
@@ -12,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -31,6 +32,7 @@ public class PostController {
             Principal principal
     ) {
         validateRequest(bindingResult);
+        validatePostImage(request.image());
         return postService.registerPost(request, principal.getName());
     }
 
@@ -41,6 +43,7 @@ public class PostController {
             Principal principal
     ) {
         validateRequest(bindingResult);
+        validatePostImage(request.image());
         return postService.updatePost(request, principal.getName());
     }
 
@@ -64,6 +67,12 @@ public class PostController {
 
     private void validateRequest(BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
+            throw new InvalidRequestException();
+        }
+    }
+
+    private void validatePostImage(MultipartFile postImage) {
+        if (postImage.isEmpty()) {
             throw new InvalidRequestException();
         }
     }

--- a/src/main/java/com/gxdxx/instagram/dto/request/CommentRegisterRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/CommentRegisterRequest.java
@@ -3,9 +3,17 @@ package com.gxdxx.instagram.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record CommentRegisterRequest(
-        @JsonProperty("post_id") @Positive Long postId,
-        @NotBlank String content
+
+        @Positive
+        @JsonProperty("post_id")
+        Long postId,
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/CommentUpdateRequest.java
@@ -2,9 +2,16 @@ package com.gxdxx.instagram.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record CommentUpdateRequest(
-        @Positive Long id,
-        @NotBlank String content
+
+        @Positive
+        Long id,
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/MessageSendRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/MessageSendRequest.java
@@ -1,11 +1,20 @@
 package com.gxdxx.instagram.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record MessageSendRequest(
-        @JsonProperty("user_id") @Positive Long userId,
-        @NotBlank String content
+
+        @Positive
+        @JsonProperty("user_id")
+        Long userId,
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/PostFeedRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/PostFeedRequest.java
@@ -3,7 +3,11 @@ package com.gxdxx.instagram.dto.request;
 import jakarta.validation.constraints.Positive;
 
 public record PostFeedRequest(
-        @Positive Long userId,
+
+        @Positive
+        Long userId,
+
         Long cursor
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/PostRegisterRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/PostRegisterRequest.java
@@ -1,11 +1,16 @@
 package com.gxdxx.instagram.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
 
 public record PostRegisterRequest(
-        @NotBlank String content,
-        @NotNull MultipartFile image
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content,
+
+        MultipartFile image
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/PostUpdateRequest.java
@@ -1,12 +1,18 @@
 package com.gxdxx.instagram.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
 
 public record PostUpdateRequest(
+
         Long id,
-        @NotBlank String content,
-        @NotNull MultipartFile image
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content,
+
+        MultipartFile image
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/ReplyRegisterRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/ReplyRegisterRequest.java
@@ -3,9 +3,17 @@ package com.gxdxx.instagram.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record ReplyRegisterRequest(
-        @JsonProperty("comment_id") @Positive Long commentId,
-        @NotBlank String content
+
+        @Positive
+        @JsonProperty("comment_id")
+        Long commentId,
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/ReplyUpdateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/ReplyUpdateRequest.java
@@ -1,10 +1,18 @@
 package com.gxdxx.instagram.dto.request;
 
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 
 public record ReplyUpdateRequest(
-        @Positive Long id,
-        @NotBlank String content
+
+        @Positive
+        Long id,
+
+        @Size(min = 2, max = 100)
+        @NotBlank
+        String content
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserLoginRequest.java
@@ -1,6 +1,17 @@
 package com.gxdxx.instagram.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-public record UserLoginRequest(@NotBlank String nickname, @NotBlank String password) {
+public record UserLoginRequest(
+
+        @Size(min = 2, max = 20)
+        @NotBlank
+        String nickname,
+
+        @Size(min = 4, max = 15)
+        @NotBlank
+        String password
+
+) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserProfileUpdateRequest.java
@@ -3,10 +3,18 @@ package com.gxdxx.instagram.dto.request;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
 
 public record UserProfileUpdateRequest(
-        @JsonProperty("nickname") @NotBlank String nickname,
-        @JsonProperty("profile_image") MultipartFile profileImage
+
+        @JsonProperty("nickname")
+        @Size(min = 2, max = 20)
+        @NotBlank
+        String nickname,
+
+        @JsonProperty("profile_image")
+        MultipartFile profileImage
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserSignUpRequest.java
@@ -1,13 +1,22 @@
 package com.gxdxx.instagram.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 public record UserSignUpRequest(
-        @NotBlank String nickname,
-        @NotBlank String password,
-        @RequestPart(value = "profile_image") MultipartFile profileImage
+
+        @Size(min = 2, max = 20)
+        @NotBlank
+        String nickname,
+
+        @Size(min = 4, max = 15)
+        @NotBlank
+        String password,
+
+        @RequestPart(value = "profile_image")
+        MultipartFile profileImage
+
 ) {
 }

--- a/src/main/java/com/gxdxx/instagram/entity/ChatRoom.java
+++ b/src/main/java/com/gxdxx/instagram/entity/ChatRoom.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.entity;
 
 import com.gxdxx.instagram.exception.UnauthorizedAccessException;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,12 +25,14 @@ public class ChatRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_a_id")
+    @JoinColumn(name = "user_a_id", nullable = false)
     private User userA;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_b_id")
+    @JoinColumn(name = "user_b_id", nullable = false)
     private User userB;
 
     private String lastMessage;

--- a/src/main/java/com/gxdxx/instagram/entity/Comment.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Comment.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -31,12 +32,14 @@ public class Comment {
 
     private boolean deleted = Boolean.FALSE;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     private Comment(String content, User user, Post post) {

--- a/src/main/java/com/gxdxx/instagram/entity/Comment.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Comment.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +24,9 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Size(min = 2, max = 100)
     @NotBlank
+    @Column(nullable = false, length = 100)
     private String content;
 
     private boolean deleted = Boolean.FALSE;

--- a/src/main/java/com/gxdxx/instagram/entity/Follow.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Follow.java
@@ -1,6 +1,7 @@
 package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,12 +23,14 @@ public class Follow {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "follower_id")
+    @JoinColumn(name = "follower_id", nullable = false)
     private User follower;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "following_id")
+    @JoinColumn(name = "following_id", nullable = false)
     private User following;
 
     private boolean deleted = Boolean.FALSE;

--- a/src/main/java/com/gxdxx/instagram/entity/Message.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Message.java
@@ -1,6 +1,8 @@
 package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,6 +25,9 @@ public class Message {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Size(min = 2, max = 100)
+    @NotBlank
+    @Column(nullable = false, length = 100)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gxdxx/instagram/entity/Message.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Message.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -30,16 +31,19 @@ public class Message {
     @Column(nullable = false, length = 100)
     private String content;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id")
+    @JoinColumn(name = "chat_room_id", nullable = false)
     private ChatRoom chatRoom;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sender_id")
+    @JoinColumn(name = "sender_id", nullable = false)
     private User sender;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "receiver_id")
+    @JoinColumn(name = "receiver_id", nullable = false)
     private User receiver;
 
     private LocalDateTime sentAt;

--- a/src/main/java/com/gxdxx/instagram/entity/Post.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Post.java
@@ -36,8 +36,9 @@ public class Post {
 
     private boolean deleted = Boolean.FALSE;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     private Post(String content, String imageUrl, User user) {

--- a/src/main/java/com/gxdxx/instagram/entity/Post.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Post.java
@@ -2,6 +2,8 @@ package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,9 +25,13 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Size(min = 2, max = 100)
     @NotBlank
+    @Column(nullable = false, length = 100)
     private String content;
 
+    @NotBlank
+    @Column(nullable = false)
     private String imageUrl;
 
     private boolean deleted = Boolean.FALSE;

--- a/src/main/java/com/gxdxx/instagram/entity/RefreshToken.java
+++ b/src/main/java/com/gxdxx/instagram/entity/RefreshToken.java
@@ -1,10 +1,8 @@
 package com.gxdxx.instagram.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,7 +18,9 @@ public class RefreshToken {
     @NotBlank
     private String refreshToken;
 
+    @Size(min = 2, max = 20)
     @NotBlank
+    @Column(nullable = false, length = 20)
     private String nickname;
 
     private RefreshToken(String token, String nickname) {

--- a/src/main/java/com/gxdxx/instagram/entity/Reply.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Reply.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -31,12 +32,14 @@ public class Reply {
 
     private boolean deleted = Boolean.FALSE;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
+    @JoinColumn(name = "comment_id", nullable = false)
     private Comment comment;
 
     private Reply(String content, User user, Comment comment) {

--- a/src/main/java/com/gxdxx/instagram/entity/Reply.java
+++ b/src/main/java/com/gxdxx/instagram/entity/Reply.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,7 +24,9 @@ public class Reply {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Size(min = 2, max = 100)
     @NotBlank
+    @Column(nullable = false, length = 100)
     private String content;
 
     private boolean deleted = Boolean.FALSE;

--- a/src/main/java/com/gxdxx/instagram/entity/User.java
+++ b/src/main/java/com/gxdxx/instagram/entity/User.java
@@ -1,10 +1,7 @@
 package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,15 +25,15 @@ public class User {
     private Long id;
 
     @Size(min = 2, max = 20)
-    @NotNull
+    @NotBlank
     @Column(nullable = false, length = 20)
     private String nickname;
 
-    @NotNull
+    @NotBlank
     @Column(nullable = false)
     private String password;
 
-    @NotNull
+    @NotBlank
     @Column(nullable = false)
     private String profileImageUrl;
 

--- a/src/main/java/com/gxdxx/instagram/entity/User.java
+++ b/src/main/java/com/gxdxx/instagram/entity/User.java
@@ -1,7 +1,10 @@
 package com.gxdxx.instagram.entity;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,13 +27,17 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank
+    @Size(min = 2, max = 20)
+    @NotNull
     @Column(nullable = false, length = 20)
     private String nickname;
 
-    @NotBlank
+    @NotNull
+    @Column(nullable = false)
     private String password;
 
+    @NotNull
+    @Column(nullable = false)
     private String profileImageUrl;
 
     private boolean deleted = Boolean.FALSE;


### PR DESCRIPTION
## 작업 내용
- 엔티티의 필드에 @Column 어노테이션을 적용해 DB 컬럼과 매핑되도록 합니다.
- 엔티티의 필드에 유효성 검증 어노테이션을 적용해 엔티티를 저장 및 수정 전 내부 로직 문제로 인한 잘못된 값을 검증합니다.
- 실제 유효성 검증은 요청으로 전달받은 DTO를 통해 수행합니다.

This closes #53 