### PR TITLE
회원 Service 리팩토링

### DIFF
--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.dto.request.UserDeleteRequest;
 import com.gxdxx.instagram.dto.request.UserLoginRequest;
 import com.gxdxx.instagram.dto.request.UserProfileUpdateRequest;
 import com.gxdxx.instagram.dto.request.UserSignUpRequest;
@@ -63,10 +64,12 @@ public class UserController {
     @Operation(summary = "회원탈퇴 메소드", description = "회원탈퇴 메소드입니다.")
     @DeleteMapping(value = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public SuccessResponse deleteUser(
-            @Parameter(name = "id", description = "회원의 id", in = ParameterIn.PATH) @PathVariable("id") Long id,
+            @Valid UserDeleteRequest request,
+            BindingResult bindingResult,
             Principal principal
     ) {
-        return userDeleteService.deleteUser(id, principal.getName());
+        validateRequest(bindingResult);
+        return userDeleteService.deleteUser(request.password(), principal.getName());
     }
 
     @ApiResponses(value = {

--- a/src/main/java/com/gxdxx/instagram/dto/request/UserDeleteRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/UserDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.gxdxx.instagram.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UserDeleteRequest(
+
+        @Schema(description = "비밀번호", example = "123123")
+        @Size(min = 4, max = 15)
+        @NotBlank
+        String password
+
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/service/user/UserDeleteService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserDeleteService.java
@@ -22,13 +22,13 @@ public class UserDeleteService {
     private final PasswordEncoder passwordEncoder;
 
     public SuccessResponse deleteUser(String password, String nickname) {
-        User deleteUser = getUserByNickname(nickname);
+        User deleteUser = findUserByNickname(nickname);
         checkPasswordMatches(password, deleteUser.getPassword());
         deleteUserData(deleteUser);
         return SuccessResponse.of("회원탈퇴를 성공했습니다.");
     }
 
-    private User getUserByNickname(String nickname) {
+    private User findUserByNickname(String nickname) {
         return userRepository.findByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
     }

--- a/src/main/java/com/gxdxx/instagram/service/user/UserDeleteService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserDeleteService.java
@@ -1,11 +1,14 @@
 package com.gxdxx.instagram.service.user;
 
+import com.gxdxx.instagram.dto.request.UserDeleteRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.PasswordNotMatchException;
 import com.gxdxx.instagram.exception.UnauthorizedAccessException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,10 +19,13 @@ public class UserDeleteService {
 
     private final UserRepository userRepository;
 
-    public SuccessResponse deleteUser(Long id, String nickname) {
-        User deleteUser = userRepository.findById(id).orElseThrow(UserNotFoundException::new);
-        if (!deleteUser.getNickname().equals(nickname)) {
-            throw new UnauthorizedAccessException();
+    private final PasswordEncoder passwordEncoder;
+
+    public SuccessResponse deleteUser(String password, String nickname) {
+        User deleteUser = userRepository.findByNickname(nickname)
+                .orElseThrow(UserNotFoundException::new);
+        if (!passwordEncoder.matches(password, deleteUser.getPassword())) {
+            throw new PasswordNotMatchException();
         }
         userRepository.delete(deleteUser);
         return SuccessResponse.of("회원탈퇴를 성공했습니다.");

--- a/src/main/java/com/gxdxx/instagram/service/user/UserDeleteService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserDeleteService.java
@@ -22,13 +22,25 @@ public class UserDeleteService {
     private final PasswordEncoder passwordEncoder;
 
     public SuccessResponse deleteUser(String password, String nickname) {
-        User deleteUser = userRepository.findByNickname(nickname)
+        User deleteUser = getUserByNickname(nickname);
+        checkPasswordMatches(password, deleteUser.getPassword());
+        deleteUserData(deleteUser);
+        return SuccessResponse.of("회원탈퇴를 성공했습니다.");
+    }
+
+    private User getUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
-        if (!passwordEncoder.matches(password, deleteUser.getPassword())) {
+    }
+
+    private void checkPasswordMatches(String password, String storedPassword) {
+        if (!passwordEncoder.matches(password, storedPassword)) {
             throw new PasswordNotMatchException();
         }
-        userRepository.delete(deleteUser);
-        return SuccessResponse.of("회원탈퇴를 성공했습니다.");
+    }
+
+    private void deleteUserData(User user) {
+        userRepository.delete(user);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/user/UserProfileQueryService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserProfileQueryService.java
@@ -19,15 +19,27 @@ public class UserProfileQueryService {
 
     @Transactional(readOnly = true)
     public UserProfileResponse findUserProfile(String nickname) {
-        User user = getUserFromNickname(nickname);
-        Long followerCount = followRepository.countByFollowing(user);
-        Long followingCount = followRepository.countByFollower(user);
-        return UserProfileResponse.of(user.getNickname(), user.getProfileImageUrl(), followerCount, followingCount);
+        User user = findUserByNickname(nickname);
+        Long followerCount = getFollowerCount(user);
+        Long followingCount = getFollowingCount(user);
+        return createProfileResponse(user, followerCount, followingCount);
     }
 
-    private User getUserFromNickname(String nickname) {
+    private User findUserByNickname(String nickname) {
         return userRepository.findByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    private Long getFollowerCount(User user) {
+        return followRepository.countByFollowing(user);
+    }
+
+    private Long getFollowingCount(User user) {
+        return followRepository.countByFollower(user);
+    }
+
+    private UserProfileResponse createProfileResponse(User user, Long followerCount, Long followingCount) {
+        return UserProfileResponse.of(user.getNickname(), user.getProfileImageUrl(), followerCount, followingCount);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/service/user/UserProfileUpdateService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserProfileUpdateService.java
@@ -21,11 +21,17 @@ public class UserProfileUpdateService {
     private final S3Uploader s3Uploader;
 
     public UserProfileUpdateResponse updateUserProfile(UserProfileUpdateRequest request, String nickname) {
-        checkNicknameDuplication(request.nickname());
+        checkNicknameEquality(request.nickname(), nickname);
         User savedUser = findUserByNickname(nickname);
         String newProfileImageUrl = uploadProfileImage(request.profileImage());
         updateProfile(savedUser, request.nickname(), newProfileImageUrl);
         return createUserProfileUpdateResponse(savedUser);
+    }
+
+    private void checkNicknameEquality(String newNickname, String savedNickname) {
+        if (!newNickname.equals(savedNickname)) {
+            checkNicknameDuplication(newNickname);
+        }
     }
 
     private void checkNicknameDuplication(String newNickname) {

--- a/src/main/java/com/gxdxx/instagram/service/user/UserProfileUpdateService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserProfileUpdateService.java
@@ -3,6 +3,7 @@ package com.gxdxx.instagram.service.user;
 import com.gxdxx.instagram.dto.request.UserProfileUpdateRequest;
 import com.gxdxx.instagram.dto.response.UserProfileUpdateResponse;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.NicknameAlreadyExistsException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.UserRepository;
 import com.gxdxx.instagram.config.s3.S3Uploader;
@@ -19,6 +20,9 @@ public class UserProfileUpdateService {
     private final S3Uploader s3Uploader;
 
     public UserProfileUpdateResponse updateUserProfile(UserProfileUpdateRequest request, String nickname) {
+        if (userRepository.findByNickname(request.nickname()).isPresent()) {
+            throw new NicknameAlreadyExistsException();
+        }
         User user = getUserFromNickname(nickname);
 
         String profileImageUrl =  s3Uploader.upload(request.profileImage(), "images");

--- a/src/main/java/com/gxdxx/instagram/service/user/UserProfileUpdateService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserProfileUpdateService.java
@@ -10,6 +10,7 @@ import com.gxdxx.instagram.config.s3.S3Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @RequiredArgsConstructor
@@ -20,20 +21,34 @@ public class UserProfileUpdateService {
     private final S3Uploader s3Uploader;
 
     public UserProfileUpdateResponse updateUserProfile(UserProfileUpdateRequest request, String nickname) {
-        if (userRepository.findByNickname(request.nickname()).isPresent()) {
-            throw new NicknameAlreadyExistsException();
-        }
-        User user = getUserFromNickname(nickname);
-
-        String profileImageUrl =  s3Uploader.upload(request.profileImage(), "images");
-
-        user.updateProfile(request.nickname(), profileImageUrl);
-        return UserProfileUpdateResponse.of(user.getId(), user.getNickname(), user.getProfileImageUrl());
+        checkNicknameDuplication(request.nickname());
+        User savedUser = findUserByNickname(nickname);
+        String newProfileImageUrl = uploadProfileImage(request.profileImage());
+        updateProfile(savedUser, request.nickname(), newProfileImageUrl);
+        return createUserProfileUpdateResponse(savedUser);
     }
 
-    private User getUserFromNickname(String nickname) {
+    private void checkNicknameDuplication(String newNickname) {
+        if (userRepository.findByNickname(newNickname).isPresent()) {
+            throw new NicknameAlreadyExistsException();
+        }
+    }
+
+    private User findUserByNickname(String nickname) {
         return userRepository.findByNickname(nickname)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    private String uploadProfileImage(MultipartFile image) {
+        return s3Uploader.upload(image, "images");
+    }
+
+    private void updateProfile(User user, String newNickname, String newProfileImageUrl) {
+        user.updateProfile(newNickname, newProfileImageUrl);
+    }
+
+    private UserProfileUpdateResponse createUserProfileUpdateResponse(User savedUser) {
+        return UserProfileUpdateResponse.of(savedUser.getId(), savedUser.getNickname(), savedUser.getProfileImageUrl());
     }
 
 }

--- a/src/test/java/com/gxdxx/instagram/service/user/UserDeleteServiceTest.java
+++ b/src/test/java/com/gxdxx/instagram/service/user/UserDeleteServiceTest.java
@@ -2,6 +2,7 @@ package com.gxdxx.instagram.service.user;
 
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.PasswordNotMatchException;
 import com.gxdxx.instagram.exception.UnauthorizedAccessException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.UserRepository;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
@@ -26,50 +28,52 @@ public class UserDeleteServiceTest {
     private UserDeleteService userDeleteService;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("[회원 탈퇴] - 성공")
     void deleteUser_success() {
-        Long userId = 1L;
         String nickname = "nickname";
+        String password = "password";
         String encodedPassword = "encodedPassword";
         String storedFileName = "storedFileName";
         User deleteUser = User.of(nickname, encodedPassword, storedFileName);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(deleteUser));
+        when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(deleteUser));
+        when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
 
-        SuccessResponse response = userDeleteService.deleteUser(userId, nickname);
+        SuccessResponse response = userDeleteService.deleteUser(password, nickname);
 
         assertEquals("회원탈퇴를 성공했습니다.", response.successMessage());
-        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).findByNickname(nickname);
         verify(userRepository, times(1)).delete(deleteUser);
     }
 
     @Test
     @DisplayName("[회원 탈퇴] - 실패 (존재하지 않는 회원)")
     void deleteUser_userNotFound() {
-        Long userId = 1L;
         String nickname = "nickname";
-        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        String password = "password";
+        when(userRepository.findByNickname(nickname)).thenReturn(Optional.empty());
 
-        assertThrows(UserNotFoundException.class, () -> userDeleteService.deleteUser(userId, nickname));
-        verify(userRepository, times(1)).findById(userId);
+        assertThrows(UserNotFoundException.class, () -> userDeleteService.deleteUser(password, nickname));
+        verify(userRepository, times(1)).findByNickname(nickname);
         verify(userRepository, never()).delete(any());
     }
 
     @Test
-    @DisplayName("[회원 탈퇴] - 실패 (인가되지 않은 회원)")
+    @DisplayName("[회원 탈퇴] - 실패 (비밀번호 불일치)")
     void deleteUser_authorizationFailed() {
-        Long userId = 1L;
         String nickname = "nickname";
-        String wrongNickname = "wrongNickname";
+        String wrongPassword = "wrongPassword";
         String encodedPassword = "encodedPassword";
         String storedFileName = "storedFileName";
-        User deleteUser = User.of(wrongNickname, encodedPassword, storedFileName);
+        User deleteUser = User.of(nickname, encodedPassword, storedFileName);
+        when(userRepository.findByNickname(nickname)).thenReturn(Optional.of(deleteUser));
+        when(passwordEncoder.matches(wrongPassword, encodedPassword)).thenReturn(false);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(deleteUser));
-
-        assertThrows(UnauthorizedAccessException.class, () -> userDeleteService.deleteUser(userId, nickname));
-        verify(userRepository, times(1)).findById(userId);
+        assertThrows(PasswordNotMatchException.class, () -> userDeleteService.deleteUser(wrongPassword, nickname));
+        verify(userRepository, times(1)).findByNickname(nickname);
         verify(userRepository, never()).delete(any());
     }
 


### PR DESCRIPTION
메소드는 하나의 기능만 수행하도록 회원 도메인과 관련된 Service 클래스를 리팩토링했다.

회원탈퇴 시 비밀번호 검증 로직을 추가했다.

프로필 수정 시 닉네임을 수정할 경우 중복된 닉네임 검증 로직을 추가했다.

추가된 로직이 있으므로 테스트코드도 수정했다.

This closes #65 