### PR TITLE
JWT Redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/gxdxx/instagram/config/SecurityConfig.java
+++ b/src/main/java/com/gxdxx/instagram/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.gxdxx.instagram.config;
 
 import com.gxdxx.instagram.config.jwt.TokenProvider;
+import com.gxdxx.instagram.service.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 public class SecurityConfig {
 
     private final TokenProvider tokenProvider;
+    private final RedisService redisService;
 
     /**
      * 직접 정의한 필터(TokenAuthenticationFilter)에서 인증 작업을 진행하기 때문에
@@ -57,7 +59,7 @@ public class SecurityConfig {
 
     @Bean
     public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(tokenProvider);
+        return new TokenAuthenticationFilter(tokenProvider, redisService);
     }
 
     @Bean

--- a/src/main/java/com/gxdxx/instagram/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/gxdxx/instagram/config/TokenAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.gxdxx.instagram.config;
 
 import com.gxdxx.instagram.config.jwt.TokenProvider;
+import com.gxdxx.instagram.service.redis.RedisService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +17,7 @@ import java.io.IOException;
 public class TokenAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
+    private final RedisService redisService;
 
     // Access Token 값이 담긴 Authorization 헤더값을 가져온 뒤 Access Token이 유효하면 인증 정보를 설정해줌
     @Override
@@ -28,22 +30,15 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         // 요청 헤더의 Authorization 키의 값 조회
         String authorizationHeader = request.getHeader(TokenProvider.HEADER_AUTHORIZATION);
         // 가져온 값에서 접두사 제거
-        String token = getAccessToken(authorizationHeader);
+        String token = tokenProvider.getAccessToken(authorizationHeader);
         // 가져온 토큰이 유효한지 확인하고, 유효할 때는 시큐리티 컨텍스트에 인증 정보를 설정
         // 이후 컨텍스트 홀더에서 getAuthentication() 메서드를 사용해 인증 정보를 가져오면 회원 객체가 반환됨
-        if (tokenProvider.validateToken(token) && tokenProvider.isAccessToken(token)) {
+        if (tokenProvider.validateToken(token) && tokenProvider.isAccessToken(token) && redisService.getValues(token).isEmpty()) {
             Authentication authentication = tokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String getAccessToken(String authorizationHeader) {
-        if (authorizationHeader != null && authorizationHeader.startsWith(TokenProvider.TOKEN_PREFIX)) {
-            return authorizationHeader.substring(TokenProvider.TOKEN_PREFIX.length());
-        }
-        return null;
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/config/jwt/RefreshTokenDto.java
+++ b/src/main/java/com/gxdxx/instagram/config/jwt/RefreshTokenDto.java
@@ -1,0 +1,10 @@
+package com.gxdxx.instagram.config.jwt;
+
+public record RefreshTokenDto(
+
+        String refreshToken,
+
+        long expiration
+
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/config/redis/RedisConfig.java
+++ b/src/main/java/com/gxdxx/instagram/config/redis/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.gxdxx.instagram.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // setKeySerializer, setValueSerializer 설정으로 redis-cli를 통해 직접 데이터를 보는게 가능하다.
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/config/redis/RedisProperties.java
+++ b/src/main/java/com/gxdxx/instagram/config/redis/RedisProperties.java
@@ -1,0 +1,18 @@
+package com.gxdxx.instagram.config.redis;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("spring.data.redis")
+public class RedisProperties {
+
+    private String host;
+
+    private int port;
+
+}

--- a/src/main/java/com/gxdxx/instagram/controller/TokenController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/TokenController.java
@@ -1,5 +1,7 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.config.jwt.TokenProvider;
+import com.gxdxx.instagram.dto.request.AccessTokenCreateRequest;
 import com.gxdxx.instagram.dto.response.ErrorResponse;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.service.token.AccessTokenCreateService;
@@ -11,11 +13,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static com.gxdxx.instagram.config.jwt.TokenProvider.REFRESH_TOKEN;
 
 @Tag(name = "tokens", description = "토큰 API")
 @RequiredArgsConstructor
@@ -30,13 +33,15 @@ public class TokenController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @Operation(summary = "액세스 토큰 생성 메소드", description = "액세스 토큰 생성 메소드입니다. 쿠키에 리프레시 토큰을 넣어주세요.")
+    @Operation(summary = "액세스 토큰 생성 메소드", description = "액세스 토큰 생성 메소드입니다. 쿠키에 리프레시 토큰, 헤더에 액세스 토큰을 넣어주세요.")
     @PostMapping(value = "/api/token", consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public SuccessResponse createAccessToken(
-            @CookieValue("refresh_token") Cookie cookie,
+            @CookieValue(REFRESH_TOKEN) Cookie cookie,
+            @RequestHeader(TokenProvider.HEADER_AUTHORIZATION) String authorizationHeader,
+            @RequestBody @Valid AccessTokenCreateRequest request,
             HttpServletResponse response
     ) {
-        return accessTokenCreateService.createAccessToken(cookie.getValue(), response);
+        return accessTokenCreateService.createAccessToken(cookie.getValue(), authorizationHeader, request, response);
     }
 
 }

--- a/src/main/java/com/gxdxx/instagram/controller/UserController.java
+++ b/src/main/java/com/gxdxx/instagram/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.gxdxx.instagram.controller;
 
+import com.gxdxx.instagram.config.jwt.TokenProvider;
 import com.gxdxx.instagram.dto.request.UserDeleteRequest;
 import com.gxdxx.instagram.dto.request.UserLoginRequest;
 import com.gxdxx.instagram.dto.request.UserProfileUpdateRequest;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class UserController {
     private final UserProfileUpdateService userProfileUpdateService;
     private final UserDeleteService userDeleteService;
     private final UserLoginService userLoginService;
+    private final UserLogoutService userLogoutService;
 
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "회원가입 성공",
@@ -87,6 +90,22 @@ public class UserController {
     ) {
         validateRequest(bindingResult);
         return userLoginService.login(request, response);
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Operation(summary = "로그아웃 메소드", description = "로그아웃 메소드입니다.")
+    @PostMapping(value = "/logout", consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public SuccessResponse logout(
+            @CookieValue(TokenProvider.REFRESH_TOKEN) Cookie cookie,
+            @RequestHeader(TokenProvider.HEADER_AUTHORIZATION) String authorizationHeader,
+            Principal principal
+    ) {
+        return userLogoutService.logout(cookie.getValue(), authorizationHeader, principal.getName());
     }
 
     @ApiResponses(value = {

--- a/src/main/java/com/gxdxx/instagram/dto/request/AccessTokenCreateRequest.java
+++ b/src/main/java/com/gxdxx/instagram/dto/request/AccessTokenCreateRequest.java
@@ -1,0 +1,17 @@
+package com.gxdxx.instagram.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record AccessTokenCreateRequest(
+
+        @Schema(description = "회원 id")
+        @JsonProperty("user_id")
+        @Positive
+        @NotNull
+        Long userId
+
+) {
+}

--- a/src/main/java/com/gxdxx/instagram/service/redis/RedisService.java
+++ b/src/main/java/com/gxdxx/instagram/service/redis/RedisService.java
@@ -1,0 +1,45 @@
+package com.gxdxx.instagram.service.redis;
+
+import com.gxdxx.instagram.exception.RefreshTokenInvalidException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    public static final String REFRESH_TOKEN_KEY_PREFIX = "RefreshToken:";
+    public static final String ACCESS_TOKEN_BLACKLIST_VALUE = "logout";
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValues(String key, String data, long duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration, TimeUnit.MILLISECONDS);
+    }
+
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void checkRefreshToken(Long userId, String refreshToken) {
+        String redisRT = this.getValues(REFRESH_TOKEN_KEY_PREFIX + userId);
+        if(!refreshToken.equals(redisRT)) {
+            throw new RefreshTokenInvalidException();
+        }
+    }
+
+}

--- a/src/main/java/com/gxdxx/instagram/service/token/AccessTokenCreateService.java
+++ b/src/main/java/com/gxdxx/instagram/service/token/AccessTokenCreateService.java
@@ -1,6 +1,7 @@
 package com.gxdxx.instagram.service.token;
 
 import com.gxdxx.instagram.config.jwt.TokenProvider;
+import com.gxdxx.instagram.dto.request.AccessTokenCreateRequest;
 import com.gxdxx.instagram.dto.response.SuccessResponse;
 import com.gxdxx.instagram.entity.User;
 import com.gxdxx.instagram.exception.RefreshTokenInvalidException;
@@ -8,10 +9,15 @@ import com.gxdxx.instagram.exception.RefreshTokenNotFoundException;
 import com.gxdxx.instagram.exception.UserNotFoundException;
 import com.gxdxx.instagram.repository.RefreshTokenRepository;
 import com.gxdxx.instagram.repository.UserRepository;
+import com.gxdxx.instagram.service.redis.RedisService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static com.gxdxx.instagram.service.redis.RedisService.ACCESS_TOKEN_BLACKLIST_VALUE;
 
 @RequiredArgsConstructor
 @Transactional
@@ -21,14 +27,19 @@ public class AccessTokenCreateService {
     private final TokenProvider tokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final RedisService redisService;
 
     // 전달받은 RefeshToken으로 토큰 유효성 검사를 진행하고, 유효한 토큰일 때 Refresh Token으로 사용자 id를 찾음
-    public SuccessResponse createAccessToken(String refreshToken, HttpServletResponse response) {
+    public SuccessResponse createAccessToken(String refreshToken, String authorizationHeader, AccessTokenCreateRequest request, HttpServletResponse response) {
         validateRefreshToken(refreshToken);
-        Long userId = findUserIdByRefreshToken(refreshToken);
-        User user = findUserById(userId);
+        Long userId = request.userId();
+        redisService.checkRefreshToken(userId, refreshToken);
+        User userToCreateAccessToken = findUserById(userId);
+        // AT가 만료되지 않은 상태에서 AT 재발급 요청을 할 경우 이전 AT를 black list에 추가
+        String accessToken = removePrefixFromAccessToken(authorizationHeader);
+        validateAndAddAccessTokenToBlacklist(accessToken);
         // 새로운 Access Token 생성
-        String newAccessToken = createAccessToken(user);
+        String newAccessToken = createAccessToken(userToCreateAccessToken);
         // 헤더에 Access Token 추가
         addAccessTokenToHeader(response, newAccessToken);
         return SuccessResponse.of("200 SUCCESS");
@@ -40,19 +51,31 @@ public class AccessTokenCreateService {
         }
     }
 
-    private Long findUserIdByRefreshToken(String refreshToken) {
-        return refreshTokenRepository.findByRefreshToken(refreshToken)
-                .orElseThrow(RefreshTokenNotFoundException::new)
-                .getUserId();
-    }
-
     private  User findUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    private String removePrefixFromAccessToken(String authorizationHeader) {
+        return tokenProvider.getAccessToken(authorizationHeader);
+    }
+
+    private void validateAndAddAccessTokenToBlacklist(String accessToken) {
+        if (tokenProvider.validateToken(accessToken)) {
+            addAccessTokenToBlacklist(accessToken);
+        }
+    }
+
+    private void addAccessTokenToBlacklist(String accessToken) {
+        redisService.setValues(
+                accessToken,
+                ACCESS_TOKEN_BLACKLIST_VALUE,
+                tokenProvider.getExpiration(accessToken) - new Date().getTime()
+        );
+    }
+
     private String createAccessToken(User user) {
-        return tokenProvider.createToken(user, TokenProvider.ACCESS_TOKEN);
+        return tokenProvider.createAccessToken(user);
     }
 
     private void addAccessTokenToHeader(HttpServletResponse response, String accessToken) {

--- a/src/main/java/com/gxdxx/instagram/service/user/UserLogoutService.java
+++ b/src/main/java/com/gxdxx/instagram/service/user/UserLogoutService.java
@@ -1,0 +1,69 @@
+package com.gxdxx.instagram.service.user;
+
+import com.gxdxx.instagram.config.jwt.TokenProvider;
+import com.gxdxx.instagram.dto.response.SuccessResponse;
+import com.gxdxx.instagram.entity.User;
+import com.gxdxx.instagram.exception.RefreshTokenInvalidException;
+import com.gxdxx.instagram.exception.UserNotFoundException;
+import com.gxdxx.instagram.repository.UserRepository;
+import com.gxdxx.instagram.service.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static com.gxdxx.instagram.service.redis.RedisService.ACCESS_TOKEN_BLACKLIST_VALUE;
+import static com.gxdxx.instagram.service.redis.RedisService.REFRESH_TOKEN_KEY_PREFIX;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class UserLogoutService {
+
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final RedisService redisService;
+
+    public SuccessResponse logout(String refreshToken, String authorizationHeader, String nickname) {
+        // AT 값에서 접두사 제거
+        String accessToken = removePrefixFromAccessToken(authorizationHeader);
+        // 로그아웃은 필터에서 AT가 검증되고 넘어올것임.
+        // RT 검증
+        validateRefreshToken(refreshToken);
+        User userToLogout = findUserByNickname(nickname);
+        // RT 삭제
+        deleteRefreshToken(userToLogout);
+        // AT blacklist 등록
+        addAccessTokenToBlacklist(accessToken);
+        return SuccessResponse.of("200 SUCCESS");
+    }
+
+    private String removePrefixFromAccessToken(String authorizationHeader) {
+        return tokenProvider.getAccessToken(authorizationHeader);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new RefreshTokenInvalidException();
+        }
+    }
+
+    private User findUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new UserNotFoundException());
+    }
+
+    private void deleteRefreshToken(User user) {
+        redisService.deleteValues(REFRESH_TOKEN_KEY_PREFIX + user.getId());
+    }
+
+    private void addAccessTokenToBlacklist(String accessToken) {
+        redisService.setValues(
+                accessToken,
+                ACCESS_TOKEN_BLACKLIST_VALUE,
+                tokenProvider.getExpiration(accessToken) - new Date().getTime()
+        );
+    }
+
+}


### PR DESCRIPTION
Redis를 사용하는 방식으로 수정했다.

Refresh Token은 Access Token 재발급을 위한 용도로 사용되기 때문에 회원 정보를 가지지 않도록 수정했다.

Redis에 기본적으로 Refresh Token만 저장이 된다. key는 회원 id이고 value는 토큰값이다.

Access Token을 Redis에 black list로 등록하는 경우는 아래 두가지이다.

- Access Token 재발급 시 기존 Access Token의 만료일자가 남았을 경우 기존 Access Token을 black list에 추가
- 로그아웃 시 Access Token을 받아 black list에 추가

black list에 추가할 때 Access Token의 만료일자만큼만 Redis에 저장하도록 한다.

인증이 필요한 요청 시 토큰 인증 필터에서 Access Token이 Redis에 black list로 저장되어있는지 확인하는 로직을 추가했다.

This closes #77 